### PR TITLE
Add graves blacklist to CarryOn config and bump version to 1.3.1

### DIFF
--- a/pack/config/carryon-common.pw.toml
+++ b/pack/config/carryon-common.pw.toml
@@ -5,4 +5,4 @@ side = "server"
 [download]
 url = "https://lutfilahdz.github.io/sekai-packwiz/main/server-files/config/carryon-common.json"
 hash-format = "sha512"
-hash = "67c05c3ada5a2a164a1fb53bdadc76d672cedd7d715091303e92ce3b674723243ae9f821a671fb1ef2212ec0dcc47d6c8c9585cf3abe11a9fa9ebad6c2440140"
+hash = "0c47202ec2adabd3357b70348f1425311667df61994256931c9e847e69928f66ca3ac73b1c1a03ff13b62374b862440a7f8964018085c4278ea1be43156e85f2"

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -2,7 +2,7 @@ hash-format = "sha256"
 
 [[files]]
 file = "config/carryon-common.pw.toml"
-hash = "6742e4995bc9f9b98037c5558ce553e5ce0cd197f5fcd1becbea8e904b8591e5"
+hash = "11b8b237299d140e3cfc325565eea9fda010512a3bfaf319b99a567099f10b7d"
 metafile = true
 
 [[files]]

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -1,6 +1,6 @@
 name = "Sekai Survival Modded"
 author = "Lutfilah Dzaky"
-version = "1.3.0"
+version = "1.3.1"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "2594ff527afb35a5a7d1287e6c07e18d88b9a34b7d9e636847ebfec23ea06948"
+hash = "7c0140f9005ac588c1d0f3767330fef501c79b9eacf26fe6b0ff004d45d9b541"
 
 [versions]
 fabric = "0.16.14"

--- a/pack/server-files/config/carryon-common.json
+++ b/pack/server-files/config/carryon-common.json
@@ -69,6 +69,7 @@
     "//blacklist": "Blacklist. Read about the format here: https://github.com/Tschipp/CarryOn/wiki/Black---and-Whitelist-Config",
     "//forbiddenTiles": "Blocks that cannot be picked up",
     "forbiddenTiles": [
+      "graves:*",
       "minecraft:spawner",
       "#forge:immovable",
       "#forge:relocation_not_supported",


### PR DESCRIPTION
Introduce a blacklist for graves in the CarryOn mod configuration to prevent interactions with the graves mod. Update the modpack version to 1.3.1.