### PR TITLE
Bump mods and dependencies version

### DIFF
--- a/pack/index.toml
+++ b/pack/index.toml
@@ -775,6 +775,11 @@ hash = "9e0de5ca33464391d73910e6cfbe90b06f21a691061003d7ad93eb34041046ad"
 metafile = true
 
 [[files]]
+file = "mods/moogs-structure-lib.pw.toml"
+hash = "8b64ba3552679ed5a622fbffb8875d6b6a185f39ca4966fed28197a4b031b6e3"
+metafile = true
+
+[[files]]
 file = "mods/moogs-voyager-structures.pw.toml"
 hash = "8f04990971801314688649b2779333700b6408c4bc6c2abc707172bf945cdcd4"
 metafile = true

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -91,7 +91,7 @@ metafile = true
 
 [[files]]
 file = "mods/badoptimizations.pw.toml"
-hash = "5dbe70f6dee859c9c2f6f13f2e8c34801fe89cc57ec94c96fc3200bed8d42531"
+hash = "7a266a082b54627e5f95aa154871114fded8c0a06af104e49cf08668b869cfad"
 metafile = true
 
 [[files]]
@@ -146,7 +146,7 @@ metafile = true
 
 [[files]]
 file = "mods/cameraoverhaul.pw.toml"
-hash = "1486599d6e290cf30708c54ce2b8caa0447f072080625213951d50665167ec56"
+hash = "360c50d7131402e9dd322ec73da30715be320f35a0376768952e622e24e75bd1"
 metafile = true
 
 [[files]]
@@ -166,7 +166,7 @@ metafile = true
 
 [[files]]
 file = "mods/cherry-villages.pw.toml"
-hash = "9d53f223cf25d390ae132f6c27829a2b4f165b911e2e00aa9d3ab138b316ef9e"
+hash = "ebd2d7b9f6991d780b9b3d1c8fd5f549ac1886ce9459d67c7f6a5aae4f1c3ad4"
 metafile = true
 
 [[files]]
@@ -196,7 +196,7 @@ metafile = true
 
 [[files]]
 file = "mods/coolrain.pw.toml"
-hash = "dd3c03678a537da1f286dd617e8d127b76b778a207864a5b1c20813bfa7304db"
+hash = "e9dc56385abbcddd52dd4fe5b59aef354c363d6353ff3d8d271ee9b1624815f5"
 metafile = true
 
 [[files]]
@@ -211,7 +211,7 @@ metafile = true
 
 [[files]]
 file = "mods/craftpresence.pw.toml"
-hash = "2f887370db35b191f96b45b27b3b69e91775f87ceeef7587aa9909a0365a4b0d"
+hash = "1b272be2b56b60336ecef056cf9f0e35a77fc8a46c8a121887c736c6cfc180ce"
 metafile = true
 
 [[files]]
@@ -226,17 +226,17 @@ metafile = true
 
 [[files]]
 file = "mods/create-fabric.pw.toml"
-hash = "7d227ef90b1918ceb348ade235a5d17c7894acbf387575e96c08920a5bad1bbb"
+hash = "e569d23d25afa6f42fb1b63925f07ed7babbfc586e9ea43279d1fa39c907bb12"
 metafile = true
 
 [[files]]
 file = "mods/create-let-the-adventure-begin.pw.toml"
-hash = "7b323c8b76960ff2963ac6724cfffae3d9afe87b9cd76d08b6641be80e9ac607"
+hash = "fa27a4afae3c0329580d41893390307f2f4e71e3f3d7e06c6ee19ec44de39a53"
 metafile = true
 
 [[files]]
 file = "mods/create-railways-navigator.pw.toml"
-hash = "33da71242eed44ccd9e93b1d5c4d9a4dc15fb5e5ce44774468b0c8ee5c2b91b7"
+hash = "2840c63302d50d82eb9c82a73784bc18b3afb51c5834c088ba202277f90cb2c3"
 metafile = true
 
 [[files]]
@@ -246,7 +246,7 @@ metafile = true
 
 [[files]]
 file = "mods/create-steam-n-rails.pw.toml"
-hash = "b79bc9976d5958f4b88ca23575e0d0dc677a2b06931108f6f7bc3fd3e46bb22c"
+hash = "833965c26ba97f777499976a7be48937f71c4e9c4dd41b972a8d620b9eafb38b"
 metafile = true
 
 [[files]]
@@ -261,7 +261,7 @@ metafile = true
 
 [[files]]
 file = "mods/creativecore.pw.toml"
-hash = "78085457d022d795c7f4f5566476fde9a8a4e81eee96db09ef7f5bd09eb34926"
+hash = "af83eb1ea0f7a36e4424248c744c1cbebb5045d361e843b873d4d89bf65ad8ad"
 metafile = true
 
 [[files]]
@@ -311,7 +311,7 @@ metafile = true
 
 [[files]]
 file = "mods/deimos.pw.toml"
-hash = "4329b514c4d806fea68e4802aa23b0d03443933dc171e5833fe1b1ea38956178"
+hash = "49faa25c5286304a16cb3626bcaa1b321a50f9df4c4c4c44640d0e67f20d9a15"
 metafile = true
 
 [[files]]
@@ -341,7 +341,7 @@ metafile = true
 
 [[files]]
 file = "mods/distanthorizons.pw.toml"
-hash = "8276518c6ba5c30439e6361e115d6b26cd0a96904f7792d1501013aa05c3512f"
+hash = "c5ea75feae4d340856611f78a29e6f1f0b7e707bfe43847f11d25fac1769dee7"
 metafile = true
 
 [[files]]
@@ -351,7 +351,7 @@ metafile = true
 
 [[files]]
 file = "mods/dripsounds.pw.toml"
-hash = "ba0948090ee94a52b1a8871e1a6ae5259a866e89c75663b8dc442bd3f1dac393"
+hash = "0c9f3108c7acc23323000945b285604bff97253183376b0557fb2d877cf7cd5d"
 metafile = true
 
 [[files]]
@@ -361,7 +361,7 @@ metafile = true
 
 [[files]]
 file = "mods/durability-tooltip.pw.toml"
-hash = "ab0a2eb7d496c659af26dd31070a778f84a7f88b17fc75fea4ad3e31075bf319"
+hash = "5d9ebe88bd5f88c680d773a765f7d4e63f3b5a1fce2e23c4d04fc52d19cccc04"
 metafile = true
 
 [[files]]
@@ -396,17 +396,17 @@ metafile = true
 
 [[files]]
 file = "mods/entity-model-features.pw.toml"
-hash = "724f38446c3830230388cec99fed286ff1e8580f0a82c1466c7d59bde4450c71"
+hash = "b13f84a7fad7d6e21cef513a9c8f8206e55f0b342b4030df540e3126ad5abb2a"
 metafile = true
 
 [[files]]
 file = "mods/entityculling.pw.toml"
-hash = "6879b46fb95e5075e524257995e7e54571e30df81364aeb339081a23a45ebd2d"
+hash = "58a487d9e3761d18f529cf141c873ea054e8f26c5e90601a3c8cf60fc723b22d"
 metafile = true
 
 [[files]]
 file = "mods/entitytexturefeatures.pw.toml"
-hash = "431846491318f66fdef523f169044383847e75d3e1ff36cccd2bf8cb10e85ae8"
+hash = "605c081279d8e4e5c98e6a50304867214185d8b8f14434b71d388a20f4ad7d5d"
 metafile = true
 
 [[files]]
@@ -421,7 +421,7 @@ metafile = true
 
 [[files]]
 file = "mods/explorify.pw.toml"
-hash = "a0b3f914a386d4236744bc749156bb7eca1014179a50e340af1ea4741198782f"
+hash = "d93c3c494955dfc44e2590ded2ee8414d582e87f2fca00575f08576ae2197d57"
 metafile = true
 
 [[files]]
@@ -436,7 +436,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-language-kotlin.pw.toml"
-hash = "f217a0233c8aef84e914e1f8e90718be2496a923725215190d375ab3140379ab"
+hash = "d7c055f277c1751122d9abc5f09015e629699e04a9383cd0c666b33436293079"
 metafile = true
 
 [[files]]
@@ -456,7 +456,7 @@ metafile = true
 
 [[files]]
 file = "mods/farmers-delight-refabricated.pw.toml"
-hash = "5c98012330282f45370e95f4206ccf214fb059b73a8b4ebe0aeb2ae57647d8d5"
+hash = "e09385ac1a1c0900b8fa619290eb0f0539949ebbc59f7604a7699485784ccc85"
 metafile = true
 
 [[files]]
@@ -471,7 +471,7 @@ metafile = true
 
 [[files]]
 file = "mods/fire-arrows-ignite-fire.pw.toml"
-hash = "a19ed801ca93fe00090e4d74595e1cc7f0890fb0ce3085e88987aa67aaec6526"
+hash = "eab371efe71a69f262b31a2fbc7502653c4f1f7960a3167ef431c5deead9e4b7"
 metafile = true
 
 [[files]]
@@ -481,7 +481,7 @@ metafile = true
 
 [[files]]
 file = "mods/forge-config-api-port.pw.toml"
-hash = "4449401b59481016fa2a66d6e749795129160cb1ab3e7932e15033c6b5815455"
+hash = "adea09f1e1b05da68cf7407992a9391b15985acf5465a888e54ae076dbd543ab"
 metafile = true
 
 [[files]]
@@ -491,12 +491,12 @@ metafile = true
 
 [[files]]
 file = "mods/formations-overworld.pw.toml"
-hash = "a9ed985d2453f61db49f2af28c30d40119a0654f9a58dc850f24eaad50417150"
+hash = "16d5efbb4c0c97fd9b5474a6f7d51e3ce4caf0c9dd7fdb16df9110be9755b6dc"
 metafile = true
 
 [[files]]
 file = "mods/formations.pw.toml"
-hash = "94ddda7ccf408a1cf1380924efca253e6ebac5353df83ef9f580b29d8e85d9cb"
+hash = "dfe0fb2bcdb8a356dae8f654710b72ea9c532c7b05afee33186de068df492ffb"
 metafile = true
 
 [[files]]
@@ -506,7 +506,7 @@ metafile = true
 
 [[files]]
 file = "mods/geckolib.pw.toml"
-hash = "486365308053b52809d840574fcf011125a146c2ab51ff8efb0f72c8cc1a759e"
+hash = "21d2df923fa369d69a40d69f6466153146bf403367430eaeb2569c1554857df8"
 metafile = true
 
 [[files]]
@@ -526,7 +526,7 @@ metafile = true
 
 [[files]]
 file = "mods/hearths.pw.toml"
-hash = "e85a99b873be94bc88f82dc924b3db1e14b70c3cd2962384ee3e0a998fb31f62"
+hash = "40b201d2061f1a0df66401984c5242a8786f24f775f9f15991a280c2a80dc715"
 metafile = true
 
 [[files]]
@@ -556,7 +556,7 @@ metafile = true
 
 [[files]]
 file = "mods/immediatelyfast.pw.toml"
-hash = "68985a3f3d2a6f829783c1bdbd27f195556992fc2c0a9738656acccf38d8c97a"
+hash = "060c6baaec85f47ba4bc2c0f4b8642b9933c27d3c166eb00ef86b4bbfd7f34a3"
 metafile = true
 
 [[files]]
@@ -606,12 +606,12 @@ metafile = true
 
 [[files]]
 file = "mods/itemphysic.pw.toml"
-hash = "e93445d4d21b7ad40204394fc4be435f1b596f8d922141e973f83528a38e0210"
+hash = "01651c0cba9c33801c0e286ab81313c98228a3871862e4c60e357c8dd6b5a111"
 metafile = true
 
 [[files]]
 file = "mods/jade-addons-fabric.pw.toml"
-hash = "fd806713c4bd32080e12e65c012ad93de6a6fae53484fa13a72603c39f3eae63"
+hash = "0893e636dbc10c1515f12a77c74f88e40cb65a01cea67c167ce65be3f56c19cb"
 metafile = true
 
 [[files]]
@@ -621,7 +621,7 @@ metafile = true
 
 [[files]]
 file = "mods/jei.pw.toml"
-hash = "a615fd6551b3d47e2d0e42e4ec30df6293bec90c135f1022113425ab8f23f7a6"
+hash = "9ea4057346d54e73b0adf8555f1c7621ff3ee09a5eec0b85824e7396bf48fde1"
 metafile = true
 
 [[files]]
@@ -641,7 +641,7 @@ metafile = true
 
 [[files]]
 file = "mods/justenoughbreeding.pw.toml"
-hash = "fdd5bb8db6166ec641236cffa0a6a098387ecc6921474ebc56225ca1704b3de9"
+hash = "d0eb389aa602b78bf203c592d17572b8e28cf516ddb065ea33ed9fd3aeca8ee1"
 metafile = true
 
 [[files]]
@@ -656,7 +656,7 @@ metafile = true
 
 [[files]]
 file = "mods/lambdynamiclights.pw.toml"
-hash = "e727cc5823b7391db5c30bbaa3769fed77533db693011d0dc8698b0e4303b71d"
+hash = "be7240c21a4acd8de01d7f6f93be18ca2a233917d32e6f6205f788432525a570"
 metafile = true
 
 [[files]]
@@ -666,7 +666,7 @@ metafile = true
 
 [[files]]
 file = "mods/lets-do-addon-compat.pw.toml"
-hash = "187f524b1d902ceafcb2d8b6675ad9f4cd849dfbbca037777170d5c52e46af47"
+hash = "6b9fe37142b700f29cfdfac1746b5502112cf944d3ed789569d7c1b98ed7e2ad"
 metafile = true
 
 [[files]]
@@ -681,22 +681,22 @@ metafile = true
 
 [[files]]
 file = "mods/lets-do-bakery-farmcharm-compat.pw.toml"
-hash = "509241ec52d3dac612233ff3e4daa84cdf9b5c94c8009ef28167a0b0db945dcd"
+hash = "452c6f62f9601c728cef3575bf537a83661ccfcbaeceb59542a0cd0d0d2d6426"
 metafile = true
 
 [[files]]
 file = "mods/lets-do-brewery-farmcharm-compat.pw.toml"
-hash = "e184bea6c376d34b3df9271852bd0bd424f6dbe1f8d64832d4a5ac8c28e2d4f1"
+hash = "1fa46cc140a1e1f028fdb0a1717022a701b4558b87c6c0506c7c82a9b80e9e1e"
 metafile = true
 
 [[files]]
 file = "mods/lets-do-candlelight-farmcharm-compat.pw.toml"
-hash = "b335ba31a6b89f856098ef4f8108866bcaab07e3a4024c4ca815614c0357fca9"
+hash = "f970ac4cc211e386a2bc289326983c03e62f5b4029b96c287d5ce980ccbdc227"
 metafile = true
 
 [[files]]
 file = "mods/lets-do-farm-charm.pw.toml"
-hash = "e06e00a944236b62565a772c254ef3f00dc72d069ae8c3787950d8617e2e620e"
+hash = "32157b1262c90a4ebee4a24028c39c2753a209b453c03c59391278acd432fc3c"
 metafile = true
 
 [[files]]
@@ -711,7 +711,7 @@ metafile = true
 
 [[files]]
 file = "mods/lets-do-vinery.pw.toml"
-hash = "62a52fffcc4b1a84d176ee33a16f39625bde634c95e63675fa7a5cd4d6fc5199"
+hash = "419bd839d19392cc602591a1bd9975e02e4f946f93f161fa793865530628af63"
 metafile = true
 
 [[files]]
@@ -721,12 +721,12 @@ metafile = true
 
 [[files]]
 file = "mods/lithium.pw.toml"
-hash = "a08a445002542d96a8481654c3f4b5e2d3c064f77b477aeaa3a1d1c3cd396ca8"
+hash = "c8695e51366b601c5e9118a5d5650d234cc25fc8d1f90ebd186c17c199ba7fca"
 metafile = true
 
 [[files]]
 file = "mods/lithostitched.pw.toml"
-hash = "5d5dd0433269a2d67240cba72a81569dbf16c7fd374ebca5d1b013a2aaf95786"
+hash = "55167e582fd4841cd6c581beb53d341e94285c216e04b1d7bff0068e875be2a6"
 metafile = true
 
 [[files]]
@@ -741,17 +741,17 @@ metafile = true
 
 [[files]]
 file = "mods/mes-moogs-end-structures.pw.toml"
-hash = "d6dee7f50e18a18f212f433e4449bb6f92eb03f1ac771532593819bbde1f0883"
+hash = "5b4b410ca9eeb3a30d769e7cdb33c6a0eacc25a6ff2ce48d61fa4124c444b700"
 metafile = true
 
 [[files]]
 file = "mods/mmmmmmmmmmmm.pw.toml"
-hash = "baf621c25806948e7407dcf49982e2b86c9a047270d57c1e3ece1e07ef28f07b"
+hash = "03b7b5e918aaf6324e4d34c1868c3f44a218b5306bd321efa89ee50ec78c2299"
 metafile = true
 
 [[files]]
 file = "mods/mns-moogs-nether-structures.pw.toml"
-hash = "78ae1714c3eb76e7696a37b25f375b65136b758c737bf4af0d6d4bc5e44e282f"
+hash = "6ce6e2bfc4317aa33bdeabdaeb780afb3b35c61c4b82e2aefe76320522bd8aae"
 metafile = true
 
 [[files]]
@@ -766,7 +766,7 @@ metafile = true
 
 [[files]]
 file = "mods/modernfix.pw.toml"
-hash = "8e706e9f53a2ec62ed4c98e2b269cf1128a21419d12551b2325b7eedc587ddf5"
+hash = "f43c82e3cc6079291ddae81445c703905b6c670dd43f444e47f5cd817944e822"
 metafile = true
 
 [[files]]
@@ -776,12 +776,12 @@ metafile = true
 
 [[files]]
 file = "mods/moogs-voyager-structures.pw.toml"
-hash = "0aab0fca2b478f500e30e4e654b95a1ccfb47ee1d25d16759d1b89f1a41ee593"
+hash = "8f04990971801314688649b2779333700b6408c4bc6c2abc707172bf945cdcd4"
 metafile = true
 
 [[files]]
 file = "mods/moonlight.pw.toml"
-hash = "8833d26bb1840c79ebd7ba91558a28fefef26ec743cb92fcb45372fcdd3a8412"
+hash = "200d34b575b506ab0503f7856cdcd4cc38030c27e0749e36f6bbe62cbeb16cec"
 metafile = true
 
 [[files]]
@@ -861,7 +861,7 @@ metafile = true
 
 [[files]]
 file = "mods/ping-wheel.pw.toml"
-hash = "f1dc4c29633a5d3e64edcfe59216302b3f85926c78efa60d7eb636473a6afe4b"
+hash = "2a0fca7186e870cd4134a7d27c42ab637c97c86a6459a7fcfb72d3e1cccfe966"
 metafile = true
 
 [[files]]
@@ -876,7 +876,7 @@ metafile = true
 
 [[files]]
 file = "mods/puzzles-lib.pw.toml"
-hash = "e7aaef7215f2419177f1b1d3240d2d61d17ca2b2e03127d92941874ad5594d6f"
+hash = "a1eff7b33a54586b6989c7bfd89992f9d315f1c656b7596649d9af7017c6af7b"
 metafile = true
 
 [[files]]
@@ -891,7 +891,7 @@ metafile = true
 
 [[files]]
 file = "mods/repurposed-structures-fabric.pw.toml"
-hash = "dd4de30039cec802d8cc950b56908c1dff1f989747a7cd545a2e85822939d69c"
+hash = "0395f9eb12d8610ab52bb09dc0e110f469652fd1267c246e7dbfc4266626e42c"
 metafile = true
 
 [[files]]
@@ -916,7 +916,7 @@ metafile = true
 
 [[files]]
 file = "mods/shifting-wares.pw.toml"
-hash = "3a73fee3d8d6b3d0c47f738d40a58ec17496c351302479302edb119af6d6a94f"
+hash = "c20896602301db52901aa53fc61ac77484d77dbdceb82c6ed165c30b939c1cc8"
 metafile = true
 
 [[files]]
@@ -926,12 +926,12 @@ metafile = true
 
 [[files]]
 file = "mods/simple-voice-chat.pw.toml"
-hash = "633c545cef2b18aa859888279ceab943f63a50409cfe6aecb85c91e530e7f7b0"
+hash = "fae2bc6c282159f6a2e55e22d19241c625a9795dddbe8bd0f0b501c8aa709be1"
 metafile = true
 
 [[files]]
 file = "mods/skinrestorer.pw.toml"
-hash = "a8c8d5846bb9c2da0f6bb3d7343c38a3cc44d1d0ce3cb9af4fa9d1daa85f234f"
+hash = "62a6f5a489aa45fda94386b89a75485312338261998ddbb2d11316f595d2c38f"
 metafile = true
 
 [[files]]
@@ -961,7 +961,7 @@ metafile = true
 
 [[files]]
 file = "mods/sound-physics-remastered.pw.toml"
-hash = "d2fbb82f0d2b6112b8b941bb25d7a3bd00deeb6cff220a13feb1248f42ef64d7"
+hash = "babadc51e87a1fb49ecfd06611810d6863f649de12da3cc4c657117bab9b1ee0"
 metafile = true
 
 [[files]]
@@ -1001,7 +1001,7 @@ metafile = true
 
 [[files]]
 file = "mods/the-lost-castle.pw.toml"
-hash = "2f4f8e457856b25ca6c51bcd01f7567e1c9763dbe2f7146397baee81244bf713"
+hash = "8cd62328b33b5d35d5659bc20a2d92357254af6950eb63fbb55d68a1f2b2a8b2"
 metafile = true
 
 [[files]]
@@ -1016,7 +1016,7 @@ metafile = true
 
 [[files]]
 file = "mods/tide.pw.toml"
-hash = "0a660c8ad55dc7406518f47816ddcf0e504ea4947d2f42e36666b0ace60bc02f"
+hash = "ed5ccbe92158e5f86845a6a7590884a07fa1e77214664d316ed283eced1a75d3"
 metafile = true
 
 [[files]]
@@ -1051,7 +1051,7 @@ metafile = true
 
 [[files]]
 file = "mods/unilib.pw.toml"
-hash = "b2cf34d261425b39117c3c258b02add0546ee66e8a9f4e3679a92faea369a06a"
+hash = "a926b20644e92b66a86a135e159f376c4166e732659840cd2e00c9b3504091e0"
 metafile = true
 
 [[files]]
@@ -1061,7 +1061,7 @@ metafile = true
 
 [[files]]
 file = "mods/unnamed-desert.pw.toml"
-hash = "796f07065a0fb5f9c2d04a658c91cdcce1a19d2839e57c819ff1e2112e4de4d5"
+hash = "6c5745a7749360b3a2d3cf6cd304b06c6388883d9ad432995f793eafb929fb67"
 metafile = true
 
 [[files]]
@@ -1086,7 +1086,7 @@ metafile = true
 
 [[files]]
 file = "mods/visual-workbench.pw.toml"
-hash = "c28f21e5e16aa98001e982453e1b2b8f99302497c645bca4a02a708cfc16577d"
+hash = "a9b241cbbff036293ceb73c9fac0f58c2b1d60cefb2aed0212fc936556a16df8"
 metafile = true
 
 [[files]]
@@ -1101,12 +1101,12 @@ metafile = true
 
 [[files]]
 file = "mods/waterframes.pw.toml"
-hash = "35a9a5e63cb30761764e8b3a7eaaff1587c36a03b36a1baf36a7e955c30cff64"
+hash = "fae1ab4ba09991a134688e5f6b370f94335308216394b78df7ae5c6a61a58cf8"
 metafile = true
 
 [[files]]
 file = "mods/watermedia.pw.toml"
-hash = "db448883024c3b6fa903231dafc93055881a9f5114708e53ea9883af8e2b1888"
+hash = "94ed03c57ff5ba47dcf19bddc80d950c4ad4ff9d49ebed54f514e4336032420b"
 metafile = true
 
 [[files]]
@@ -1126,12 +1126,12 @@ metafile = true
 
 [[files]]
 file = "mods/xaeros-minimap.pw.toml"
-hash = "077c0e3257cc9fa57540c2267a18cca9fc850cd76f23b484ed07b9d98366d783"
+hash = "fd725a2383164ee2866a41635b0a8baf4cc1506d33df1ce1cc1455ab98a32e01"
 metafile = true
 
 [[files]]
 file = "mods/xaeros-world-map.pw.toml"
-hash = "60f00296654edefcfa3d462dfc06984307af073be5c4aa25255bda559352e86a"
+hash = "7598f0435251f845fdf85c8ed2ac612b2d0404e0ee73a1fcdebaf4eb6c95296d"
 metafile = true
 
 [[files]]
@@ -1141,12 +1141,12 @@ metafile = true
 
 [[files]]
 file = "mods/yes-steve-model.pw.toml"
-hash = "2b403560c62912e9dbc2b6dd9d8b941b15be5a1ffc55b883f49099efc04ec83a"
+hash = "2bc346324fee481a509bb7ef0294b8fc6dad44d24470149823d257bba1ebd585"
 metafile = true
 
 [[files]]
 file = "mods/your-reputation.pw.toml"
-hash = "f85ca367860d6fa42e257f226bbcdd47d3721f00d4bef9652c7ae68b61a6253d"
+hash = "68c363e396dcb7fd1e93cb550f5c0ae8f75f8a9244eb1b93b67b8e083d33d4d4"
 metafile = true
 
 [[files]]

--- a/pack/mods/badoptimizations.pw.toml
+++ b/pack/mods/badoptimizations.pw.toml
@@ -1,13 +1,13 @@
 name = "BadOptimizations"
-filename = "BadOptimizations-2.2.3-1.20.1.jar"
+filename = "BadOptimizations-2.4.0-1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/g96Z4WVZ/versions/6Js5HJ5e/BadOptimizations-2.2.3-1.20.1.jar"
+url = "https://cdn.modrinth.com/data/g96Z4WVZ/versions/7JVYse6h/BadOptimizations-2.4.0-1.20.1.jar"
 hash-format = "sha512"
-hash = "74020601544eacc77804981173957bdd839a0a4688e237483f5ce80a299a14b893abe11a23f60c44162ea8a4f9f3ac2952d0aade9875f87b4b1ef3ef8a254754"
+hash = "1e47a309bc7f8669104b15739f9b803a90dde1d4e31c5df53f65c926b75b5e3a9f44ba04ab02f2250b70275ed8c3ca374af81889937e2b02bc45cd15cf49fab0"
 
 [update]
 [update.modrinth]
 mod-id = "g96Z4WVZ"
-version = "6Js5HJ5e"
+version = "7JVYse6h"

--- a/pack/mods/cameraoverhaul.pw.toml
+++ b/pack/mods/cameraoverhaul.pw.toml
@@ -1,13 +1,13 @@
 name = "Camera Overhaul"
-filename = "CameraOverhaul-v2.0.4-fabric+mc[1.20.0-1.20.5].jar"
+filename = "CameraOverhaul-v2.0.5-fabric+mc[1.20.0-1.20.5].jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/m0oRwcZx/versions/4oWNKGuh/CameraOverhaul-v2.0.4-fabric%2Bmc%5B1.20.0-1.20.5%5D.jar"
+url = "https://cdn.modrinth.com/data/m0oRwcZx/versions/AOOtoo5Q/CameraOverhaul-v2.0.5-fabric%2Bmc%5B1.20.0-1.20.5%5D.jar"
 hash-format = "sha512"
-hash = "c4c47e5eace7a18733cb5444c997597d132bbc7b79ae11628c27fe4f42973e8094de5ad39161660a3e9a7d9e8448f5f41b7ff026231889aca646635be6ed92a5"
+hash = "59bc88718d9ec8c2bfd70e755dfba38d56b209c1dc8109a6babcaacbd513240bbfb0d2b20d15500c85ab4af4a27eff7c700c1aae63573415b227226c16ec0b19"
 
 [update]
 [update.modrinth]
 mod-id = "m0oRwcZx"
-version = "4oWNKGuh"
+version = "AOOtoo5Q"

--- a/pack/mods/cherry-villages.pw.toml
+++ b/pack/mods/cherry-villages.pw.toml
@@ -1,13 +1,13 @@
 name = "Cherry Grove Villages"
-filename = "cherry-villages-1.1.1.jar"
+filename = "cherry-villages-1.1.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/Xtpwas3W/versions/G5w7L326/cherry-villages-1.1.1.jar"
+url = "https://cdn.modrinth.com/data/Xtpwas3W/versions/4ql5hqQf/cherry-villages-1.1.2.jar"
 hash-format = "sha512"
-hash = "358b7e1a3a9a3de21943331002a6670ba5133e176b5722cef69598e8411106d3378672e6af35d5489f2d00712a87490230f88ded2a59822c5cb856c28ab7cc5c"
+hash = "e6c6dea808f85a53758424c9d0ad619416db482978d51f7c1aa35bd98cba9eca4eaee24bb8de7d4a1f0888ca32e1edb94dde7c6b8bfa901bf1b89eafdb54b847"
 
 [update]
 [update.modrinth]
 mod-id = "Xtpwas3W"
-version = "G5w7L326"
+version = "4ql5hqQf"

--- a/pack/mods/coolrain.pw.toml
+++ b/pack/mods/coolrain.pw.toml
@@ -1,13 +1,13 @@
 name = "Cool Rain"
-filename = "coolrain-1.2.0-1.20.1.jar"
+filename = "coolrain-1.3.1-1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/iDyqnQLT/versions/6r3KQJqu/coolrain-1.2.0-1.20.1.jar"
+url = "https://cdn.modrinth.com/data/iDyqnQLT/versions/prsLl8Qm/coolrain-1.3.1-1.20.1.jar"
 hash-format = "sha512"
-hash = "f73ff9ecbca22ac59c2d761beb9d055f6fd47bb2cc0b44271ca9a0f962003767c0c19fd50fae87b1801f7dbc026b6b3c8841ebe495886b522b7dbc7baa537447"
+hash = "13b16a99e4f906b30d4e6a8d33b1aab1134ac18feb8eca6538e710548464d147f8e39b8c2d6cb1fb31c4b29a2a9817ac440ac5ed54a4aea1794a298da34cff21"
 
 [update]
 [update.modrinth]
 mod-id = "iDyqnQLT"
-version = "6r3KQJqu"
+version = "prsLl8Qm"

--- a/pack/mods/craftpresence.pw.toml
+++ b/pack/mods/craftpresence.pw.toml
@@ -1,13 +1,13 @@
 name = "CraftPresence"
-filename = "CraftPresence-2.6.1+1.20.1-fabric.jar"
+filename = "CraftPresence-2.7.0+1.20.1-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/DFqQfIBR/versions/J3mkfoC1/CraftPresence-2.6.1%2B1.20.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/DFqQfIBR/versions/zXGDHt7g/CraftPresence-2.7.0%2B1.20.1-fabric.jar"
 hash-format = "sha512"
-hash = "a6b782597ad77d200cb6a5c6a655f82929d64a2820e4f5a410abb4d3e84683ec5037031a3578f59a367ea150b47bd30cdc64032a57027b2ca325024a2cd2537c"
+hash = "8e3151e61e44196200e826995e733c1c4fb6cb194b07cdd10519f4d5bef384febe2729d4e9776c001aa08978ca732ea4163aa8c9a1d8e712395d93adc2140073"
 
 [update]
 [update.modrinth]
 mod-id = "DFqQfIBR"
-version = "J3mkfoC1"
+version = "zXGDHt7g"

--- a/pack/mods/create-fabric.pw.toml
+++ b/pack/mods/create-fabric.pw.toml
@@ -1,6 +1,7 @@
 name = "Create Fabric"
 filename = "create-fabric-0.5.1-j-build.1631+mc1.20.1.jar"
 side = "both"
+pin = true
 
 [download]
 url = "https://cdn.modrinth.com/data/Xbc0uyRg/versions/7Ub71nPb/create-fabric-0.5.1-j-build.1631%2Bmc1.20.1.jar"

--- a/pack/mods/create-let-the-adventure-begin.pw.toml
+++ b/pack/mods/create-let-the-adventure-begin.pw.toml
@@ -1,13 +1,13 @@
 name = "Create: Let The Adventure Begin"
-filename = "create_ltab-2.7.8.1.jar"
+filename = "create_ltab-3.4.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/fUa6OtBG/versions/PkQg23TD/create_ltab-2.7.8.1.jar"
+url = "https://cdn.modrinth.com/data/fUa6OtBG/versions/WbTeTwiv/create_ltab-3.4.2.jar"
 hash-format = "sha512"
-hash = "b9b46196ba2e77478122b08bf58abcc357c6a2ad0e91eeaf1941c954cb26e34b072512a3f6ccbc59655c9cc06fa4bb243bd339abb401889af598264e3ed2aadf"
+hash = "e261a9e2604b8d30c0778f74b8628183bea719c37e533568b7372698d9af7175d69228ae05640d3c158eedc6631f38efc9fb5e3c5497ff531a09c806273c86cc"
 
 [update]
 [update.modrinth]
 mod-id = "fUa6OtBG"
-version = "PkQg23TD"
+version = "WbTeTwiv"

--- a/pack/mods/create-railways-navigator.pw.toml
+++ b/pack/mods/create-railways-navigator.pw.toml
@@ -1,6 +1,7 @@
 name = "Create Railways Navigator"
 filename = "createrailwaysnavigator-fabric-1.20.1-beta-0.8.4.jar"
 side = "both"
+pin = true
 
 [download]
 url = "https://cdn.modrinth.com/data/Dq3STxps/versions/fXKmWm2r/createrailwaysnavigator-fabric-1.20.1-beta-0.8.4.jar"

--- a/pack/mods/create-steam-n-rails.pw.toml
+++ b/pack/mods/create-steam-n-rails.pw.toml
@@ -1,6 +1,7 @@
 name = "Create: Steam 'n' Rails"
 filename = "Steam_Rails-1.6.9+fabric-mc1.20.1.jar"
 side = "both"
+pin = true
 
 [download]
 url = "https://cdn.modrinth.com/data/ZzjhlDgM/versions/VFhdqLko/Steam_Rails-1.6.9%2Bfabric-mc1.20.1.jar"

--- a/pack/mods/creativecore.pw.toml
+++ b/pack/mods/creativecore.pw.toml
@@ -1,13 +1,13 @@
 name = "CreativeCore"
-filename = "CreativeCore_FABRIC_v2.12.33_mc1.20.1.jar"
+filename = "CreativeCore_FABRIC_v2.12.34_mc1.20.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/OsZiaDHq/versions/pcUy2Oig/CreativeCore_FABRIC_v2.12.33_mc1.20.1.jar"
+url = "https://cdn.modrinth.com/data/OsZiaDHq/versions/HoxFnPO8/CreativeCore_FABRIC_v2.12.34_mc1.20.1.jar"
 hash-format = "sha512"
-hash = "14040744178fb87adafe525a7f2eda0512e1154b0c29e702265aa948dec9cc65bdc064f72d6f023907d321221e7fb5c1309ddcd6d96d419b1a0c46809fb6c7cc"
+hash = "d05bd29d58de3670f18e1430ee06d1e0c390412fbd8305f8bba6cafd9afedb6cded92ea8f35096b436e4829903c14e0e756b0ce27d4a218293b7a7df4df47aa8"
 
 [update]
 [update.modrinth]
 mod-id = "OsZiaDHq"
-version = "pcUy2Oig"
+version = "HoxFnPO8"

--- a/pack/mods/deimos.pw.toml
+++ b/pack/mods/deimos.pw.toml
@@ -1,13 +1,13 @@
 name = "Deimos"
-filename = "deimos-1.20.1-fabric-2.2.jar"
+filename = "deimos-1.20.1-fabric-2.5.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/WQaxNzFg/versions/iUVAo3IR/deimos-1.20.1-fabric-2.2.jar"
+url = "https://cdn.modrinth.com/data/WQaxNzFg/versions/U2deza7C/deimos-1.20.1-fabric-2.5.jar"
 hash-format = "sha512"
-hash = "ef286c8c52e70d49fa32b0825ee78e45ec0abe002a3a979aec32ccf90afb8e1dd89c5d9cb9ff392c706c947fbbd20821aa29434796b4a1ba1f787ddafe0c025b"
+hash = "c843dcfb6b47600173d72e23f9d17a1690805af8070e6d53469a7b3a2b26f6750f3f415bd95de20bbc2ad348f778dba309d59e29d3710185fb517c033e64941d"
 
 [update]
 [update.modrinth]
 mod-id = "WQaxNzFg"
-version = "iUVAo3IR"
+version = "U2deza7C"

--- a/pack/mods/distanthorizons.pw.toml
+++ b/pack/mods/distanthorizons.pw.toml
@@ -1,13 +1,13 @@
 name = "Distant Horizons"
-filename = "DistantHorizons-fabric-forge-2.3.2-b-1.20.1.jar"
+filename = "DistantHorizons-2.3.6-b-1.20.1-fabric-forge.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/uCdwusMi/versions/vSDePnsB/DistantHorizons-fabric-forge-2.3.2-b-1.20.1.jar"
+url = "https://cdn.modrinth.com/data/uCdwusMi/versions/HSc151Xv/DistantHorizons-2.3.6-b-1.20.1-fabric-forge.jar"
 hash-format = "sha512"
-hash = "14f5548cffa24fabdcfce6626fc813db42e28350a126833a54e1c54e13e6b393e232b5a0d55fe6bc6f7e273061adaade67f8a8bbee9503cdaf869c28db0995b7"
+hash = "33ef25a118872298d546a954bfb625e0b9573286392a4df15a929cfc382bd7224c056bb97b680b6cbb109814150cf56173cfe086295d741ef15b08259bed1e33"
 
 [update]
 [update.modrinth]
 mod-id = "uCdwusMi"
-version = "vSDePnsB"
+version = "HSc151Xv"

--- a/pack/mods/dripsounds.pw.toml
+++ b/pack/mods/dripsounds.pw.toml
@@ -1,13 +1,13 @@
 name = "Drip Sounds"
-filename = "Drip Sounds-0.5.1+1.20.4-Fabric.jar"
+filename = "Drip Sounds-0.5.2+1.20.4-Fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/T8MMXTpr/versions/qB0QZH84/Drip%20Sounds-0.5.1%2B1.20.4-Fabric.jar"
+url = "https://cdn.modrinth.com/data/T8MMXTpr/versions/ypXuGxlW/Drip%20Sounds-0.5.2%2B1.20.4-Fabric.jar"
 hash-format = "sha512"
-hash = "894e0d798686e77d8d6dba818b18a50f850a6d6bbfc49463c4b08520e1baecf6ffc06753f3fc8ef0a98bdfb101b9fad32ea61d370f0a9123bb721807d1a675b8"
+hash = "687ad64f3d867817fd64289556042c4c40cf2d58373a49d10e252f1e1777270249fe93addf3dc7236dccb13dc535a8c9d83d64bb4eb62a7bd9feb78be63c5e17"
 
 [update]
 [update.modrinth]
 mod-id = "T8MMXTpr"
-version = "qB0QZH84"
+version = "ypXuGxlW"

--- a/pack/mods/durability-tooltip.pw.toml
+++ b/pack/mods/durability-tooltip.pw.toml
@@ -1,13 +1,13 @@
 name = "Durability Tooltip"
-filename = "durabilitytooltip-1.1.5-fabric-mc1.20.jar"
+filename = "durabilitytooltip-1.1.6-fabric-mc1.20.4.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/smUP7V3r/versions/WmJeyttw/durabilitytooltip-1.1.5-fabric-mc1.20.jar"
+url = "https://cdn.modrinth.com/data/smUP7V3r/versions/FwvzZjWQ/durabilitytooltip-1.1.6-fabric-mc1.20.4.jar"
 hash-format = "sha512"
-hash = "207d3f32d031bfc391ab267c64f87b9a90b0370aa5e579c217f6774f6a69aeac141c7b8a013d144ccde4f0ed0ce162071358e55cff632fb3d82ad4de8efcf5a3"
+hash = "fe918d13a83558874db9b8bf4a269ba1a1b40fb15a47ee5f4c56feb9370a26e2ff485dbcac1001fa57459a09bbb78f395a70ed14439b62596dce6612aa5dc8ff"
 
 [update]
 [update.modrinth]
 mod-id = "smUP7V3r"
-version = "WmJeyttw"
+version = "FwvzZjWQ"

--- a/pack/mods/entity-model-features.pw.toml
+++ b/pack/mods/entity-model-features.pw.toml
@@ -1,13 +1,13 @@
 name = "[EMF] Entity Model Features"
-filename = "entity_model_features_fabric_1.20.1-2.4.1.jar"
+filename = "entity_model_features_1.20.1-fabric-3.0.7.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/4I1XuqiY/versions/X2NBK99f/entity_model_features_fabric_1.20.1-2.4.1.jar"
+url = "https://cdn.modrinth.com/data/4I1XuqiY/versions/98XZmlck/entity_model_features_1.20.1-fabric-3.0.7.jar"
 hash-format = "sha512"
-hash = "6b078e98ed5bf6eb6437a2230b15b32bb1579973ccdb418f3778eb1e745289ccc5e202cb0145558fa815a864847ba7396cfe5ba44df561e651d3da5cee7dd33b"
+hash = "1c22af6267208c971d7f885eb6aaa1b451e681719e8b922f0f055b3a7260e2200fcd001168aef2bdb99f9798b613ee7d38ff9ea3b545ace3e5052e2ac314fd38"
 
 [update]
 [update.modrinth]
 mod-id = "4I1XuqiY"
-version = "X2NBK99f"
+version = "98XZmlck"

--- a/pack/mods/entityculling.pw.toml
+++ b/pack/mods/entityculling.pw.toml
@@ -1,13 +1,13 @@
 name = "Entity Culling"
-filename = "entityculling-fabric-1.8.0-mc1.20.1.jar"
+filename = "entityculling-fabric-1.9.3-mc1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/NNAgCjsB/versions/JrOhNEba/entityculling-fabric-1.8.0-mc1.20.1.jar"
+url = "https://cdn.modrinth.com/data/NNAgCjsB/versions/WWoTbpsx/entityculling-fabric-1.9.3-mc1.20.1.jar"
 hash-format = "sha512"
-hash = "0781c1aa6e37b533eb6bb8e3ead674d21301aa706612398739c006899ac1b04c6bcc62a25e6ad3587b3c2f05211f88a01eb8c1b202929108237448b8b9909ba5"
+hash = "1de922d9c423567dabb81a44a7f3a33aa34559458e5fff7168ece0177f71928c7d92b067ecc5f4340c41cbaabf909af9b11c481525b70394e60cbfae15f47bcd"
 
 [update]
 [update.modrinth]
 mod-id = "NNAgCjsB"
-version = "JrOhNEba"
+version = "WWoTbpsx"

--- a/pack/mods/entitytexturefeatures.pw.toml
+++ b/pack/mods/entitytexturefeatures.pw.toml
@@ -1,13 +1,13 @@
 name = "[ETF] Entity Texture Features"
-filename = "entity_texture_features_fabric_1.20.1-6.2.9.jar"
+filename = "entity_texture_features_1.20.1-fabric-7.0.6.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/BVzZfTc1/versions/WvkMQbYb/entity_texture_features_fabric_1.20.1-6.2.9.jar"
+url = "https://cdn.modrinth.com/data/BVzZfTc1/versions/6Ldn1yiR/entity_texture_features_1.20.1-fabric-7.0.6.jar"
 hash-format = "sha512"
-hash = "56d65ccc56ee45e6a5aeb330bad0e59ddbec47fb3468dad1e42db8952ab70f2fd2eeda1046ff4394ac89e35941261623ee71a7a0e580fffa4f86971f615bbfa8"
+hash = "4aeea32e0a152fd2388058cc25dd4f0ac602d767c4c9c11a1e1c4841f89b0124208ce93467c5ac69e2599b7aab774557ec2cc5cd84d8079306633ec89677b510"
 
 [update]
 [update.modrinth]
 mod-id = "BVzZfTc1"
-version = "WvkMQbYb"
+version = "6Ldn1yiR"

--- a/pack/mods/explorify.pw.toml
+++ b/pack/mods/explorify.pw.toml
@@ -1,13 +1,13 @@
 name = "Explorify"
-filename = "Explorify v1.6.2 f10-48.jar"
+filename = "Explorify v1.6.4 f15-88.mod.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/HSfsxuTo/versions/yRSH0sWM/Explorify%20v1.6.2%20f10-48.jar"
+url = "https://cdn.modrinth.com/data/HSfsxuTo/versions/9vHj342y/Explorify%20v1.6.4%20f15-88.mod.jar"
 hash-format = "sha512"
-hash = "3d9ec324a1cbe4d98bb4b47bea721e1b629e11ba9b2c07d6da7a844b941f2ce71092edfbe56c62c8e14c7eda15652986de464b80ececb22334181510f374ccbb"
+hash = "601ee61e3619ab6a929ff06e4e3db6cc480d97a19e5716ac40a2a325d2d609b857a1ac17f2c0ed2b242e662b5486f4e0f59584fbd47acd481b318c45c244254b"
 
 [update]
 [update.modrinth]
 mod-id = "HSfsxuTo"
-version = "yRSH0sWM"
+version = "9vHj342y"

--- a/pack/mods/fabric-language-kotlin.pw.toml
+++ b/pack/mods/fabric-language-kotlin.pw.toml
@@ -1,13 +1,13 @@
 name = "Fabric Language Kotlin"
-filename = "fabric-language-kotlin-1.13.4+kotlin.2.2.0.jar"
+filename = "fabric-language-kotlin-1.13.7+kotlin.2.2.21.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/Ha28R6CL/versions/mccDBWqV/fabric-language-kotlin-1.13.4%2Bkotlin.2.2.0.jar"
+url = "https://cdn.modrinth.com/data/Ha28R6CL/versions/LcgnDDmT/fabric-language-kotlin-1.13.7%2Bkotlin.2.2.21.jar"
 hash-format = "sha512"
-hash = "26b6b4499bf872ebc2c666227b2ed721ce0e33a8e8b19632971250e5cb6e0b9f35aef15a07ce53cf4755285d9d38c4e05a5f1357bad544d44b9e30b87c0a0055"
+hash = "0453a8a4eb8d791b5f0097a6628fae6f13b6dfba1e2bd1f91218769123808c4396a88bcdfc785f1d6bca348f267b32afc2aa9e0d5ec93a7b35bcfe295268c7bc"
 
 [update]
 [update.modrinth]
 mod-id = "Ha28R6CL"
-version = "mccDBWqV"
+version = "LcgnDDmT"

--- a/pack/mods/farmers-delight-refabricated.pw.toml
+++ b/pack/mods/farmers-delight-refabricated.pw.toml
@@ -1,13 +1,13 @@
 name = "Farmer's Delight Refabricated"
-filename = "FarmersDelight-1.20.1-2.4.0+refabricated.jar"
+filename = "FarmersDelight-1.20.1-2.4.1+refabricated.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/7vxePowz/versions/PB4pwRax/FarmersDelight-1.20.1-2.4.0%2Brefabricated.jar"
+url = "https://cdn.modrinth.com/data/7vxePowz/versions/Z8UNayLO/FarmersDelight-1.20.1-2.4.1%2Brefabricated.jar"
 hash-format = "sha512"
-hash = "298a416f5718926dfb825725705f3baa2b1b1ae0d8462df3fa0ca0f9d9f681570ef431b9ec37e0cdb52c82c195c6d010671a5e2b235fa182c4bcbf9c2978db79"
+hash = "4fa3d8756af6df2135f19b6b78972b098e75fbfb189252288f782ad00c2a56ce6b12320e8fe8975c250f0cc001daeafb24a91bb1c09717c01302225807599450"
 
 [update]
 [update.modrinth]
 mod-id = "7vxePowz"
-version = "PB4pwRax"
+version = "Z8UNayLO"

--- a/pack/mods/fire-arrows-ignite-fire.pw.toml
+++ b/pack/mods/fire-arrows-ignite-fire.pw.toml
@@ -1,13 +1,13 @@
 name = "Fire Arrows Ignite Fire"
-filename = "firearrows-fabric-1.20.1-13.2.jar"
+filename = "firearrows-fabric-1.20.1-13.3.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/NoajjpZQ/versions/SWIhIJYC/firearrows-fabric-1.20.1-13.2.jar"
+url = "https://cdn.modrinth.com/data/NoajjpZQ/versions/cSxx0RVK/firearrows-fabric-1.20.1-13.3.jar"
 hash-format = "sha512"
-hash = "3b8412d10fec0557b5f7cbb7a4a9f32ee5338cbdd1c83e9a2a217ca79a5cee007ee36f15eb65c55eee3ff98f1199b9e02f124811a9695d29fccc9b611cc040eb"
+hash = "5c9fb2b54bb138c6f1ab862ce406d042a166ccee872f3fe55d09ec669abccc1b230f05a3ffdec00aa50e71e0a6a55ce2a15a0d04e17fc85a1b2bdbd6cf29634b"
 
 [update]
 [update.modrinth]
 mod-id = "NoajjpZQ"
-version = "SWIhIJYC"
+version = "cSxx0RVK"

--- a/pack/mods/forge-config-api-port.pw.toml
+++ b/pack/mods/forge-config-api-port.pw.toml
@@ -1,13 +1,13 @@
 name = "Forge Config API Port"
-filename = "ForgeConfigAPIPort-v8.0.2-1.20.1-Fabric.jar"
+filename = "ForgeConfigAPIPort-v8.0.3-1.20.1-Fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/ohNO6lps/versions/1aKtMQZE/ForgeConfigAPIPort-v8.0.2-1.20.1-Fabric.jar"
+url = "https://cdn.modrinth.com/data/ohNO6lps/versions/HvR3IdRE/ForgeConfigAPIPort-v8.0.3-1.20.1-Fabric.jar"
 hash-format = "sha512"
-hash = "c74fda4c25f42f182cae4ef2abaceb6992f14015a9b97570460c98f3cec15db6f7f2806f970efa1d10ffab62dd50257f8486cb586da129459225e3aa8db71ae0"
+hash = "15144d6d7b74dfbe2eede6e3b0aa0c841670be1bd6121608bc28f3b1e46846ccd36b506060a081c988da96cf46fce8bf2e55601e3934b9a52d22dc2fa6cbfd32"
 
 [update]
 [update.modrinth]
 mod-id = "ohNO6lps"
-version = "1aKtMQZE"
+version = "HvR3IdRE"

--- a/pack/mods/formations-overworld.pw.toml
+++ b/pack/mods/formations-overworld.pw.toml
@@ -1,13 +1,13 @@
 name = "Formations Overworld"
-filename = "formationsoverworld-1.0.4.jar"
+filename = "formationsoverworld-1.0.5-mc1.20.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/KX1XC0Oo/versions/APtZazrk/formationsoverworld-1.0.4.jar"
+url = "https://cdn.modrinth.com/data/KX1XC0Oo/versions/oojsZqpL/formationsoverworld-1.0.5-mc1.20.jar"
 hash-format = "sha512"
-hash = "4ef9a05e37f1277c801541d0750168bce5dcf8f56a306ffd31aee05bcb1eb11d6f2e4538937c0150128aadbf9bff3538062d572e40df7dbb8b3ded9e3a20aabf"
+hash = "4fabff31bd82835d9950b75d7678d1feeb169859ddb57fe1ed70512bf4b120c13fd4ebdfe0f718dbca54622e2e9fc3a8dce2c4c3ccf657c6df11f1255ea4bf41"
 
 [update]
 [update.modrinth]
 mod-id = "KX1XC0Oo"
-version = "APtZazrk"
+version = "oojsZqpL"

--- a/pack/mods/formations.pw.toml
+++ b/pack/mods/formations.pw.toml
@@ -1,13 +1,13 @@
 name = "Formations (Structure Library)"
-filename = "formations-1.0.3-fabric-mc1.20.2.jar"
+filename = "formations-1.0.4-fabric-mc1.20.2.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/tPe4xnPd/versions/F4xBttNI/formations-1.0.3-fabric-mc1.20.2.jar"
+url = "https://cdn.modrinth.com/data/tPe4xnPd/versions/FbtyN8OC/formations-1.0.4-fabric-mc1.20.2.jar"
 hash-format = "sha512"
-hash = "9cb0939431006be4e24272f878ed73eff131d756321cfbe059ac8064621baf2e5a8eb292dcfdaddaba91726dbe96b4face97c8daca25c83da0756de7c827cf1b"
+hash = "1afc89fff07164aaa9702d78e32113c72dbe0a034887ce9f75834303594b9a75a94b19dafd96d95cb6f0726788b35a270f6a3166c75f41a20d7d78dc4e40249b"
 
 [update]
 [update.modrinth]
 mod-id = "tPe4xnPd"
-version = "F4xBttNI"
+version = "FbtyN8OC"

--- a/pack/mods/geckolib.pw.toml
+++ b/pack/mods/geckolib.pw.toml
@@ -1,13 +1,13 @@
 name = "Geckolib"
-filename = "geckolib-fabric-1.20.1-4.7.2.jar"
+filename = "geckolib-fabric-1.20.1-4.8.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/8BmcQJ2H/versions/ezKSGafs/geckolib-fabric-1.20.1-4.7.2.jar"
+url = "https://cdn.modrinth.com/data/8BmcQJ2H/versions/AXhbVyuq/geckolib-fabric-1.20.1-4.8.2.jar"
 hash-format = "sha512"
-hash = "22e7e59f4c708f927f0e7c17e92491a25bb233ecfc6993b6f01d7f6c1a9fe0e88eb1f0a5f019a1bc1d60095a77b88be903e7e5b0132e214d43c5ba28087f00f7"
+hash = "cf0f40b02ce712610984c486ed6c7fa0c46f5926da0f8a4d329622dfaadf96a90bd1c2f9afdfc08082a66fb6e9dbf4d6853a9405f16c856bf0b55c62efcbb0a6"
 
 [update]
 [update.modrinth]
 mod-id = "8BmcQJ2H"
-version = "ezKSGafs"
+version = "AXhbVyuq"

--- a/pack/mods/hearths.pw.toml
+++ b/pack/mods/hearths.pw.toml
@@ -1,13 +1,13 @@
 name = "Hearths"
-filename = "Hearths v1.0.4 f12-80.mod.jar"
+filename = "Hearths v1.0.5.mod.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/XCIMrYn0/versions/lSHELdna/Hearths%20v1.0.4%20f12-80.mod.jar"
+url = "https://cdn.modrinth.com/data/XCIMrYn0/versions/tu78cSah/Hearths%20v1.0.5.mod.jar"
 hash-format = "sha512"
-hash = "6059f753f51825d46710bdb7d60c80b73a8501bf7c62b0d9b69f76625deacad78ef51c3a2ef81118cb48a7d2f2d74064c36028d280d63b4408963bc251922e42"
+hash = "c30f4444e0e844185b75b91f2375d3897dd969f7b90df63276cc1e7553412333a632f86c7b88f97708ed8862922630170e82b45cd08762f43a7ede2ebbea51c7"
 
 [update]
 [update.modrinth]
 mod-id = "XCIMrYn0"
-version = "lSHELdna"
+version = "tu78cSah"

--- a/pack/mods/immediatelyfast.pw.toml
+++ b/pack/mods/immediatelyfast.pw.toml
@@ -1,13 +1,13 @@
 name = "ImmediatelyFast"
-filename = "ImmediatelyFast-Fabric-1.5.0+1.20.4.jar"
+filename = "ImmediatelyFast-Fabric-1.5.2+1.20.4.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/5ZwdcRci/versions/6QvRWWbF/ImmediatelyFast-Fabric-1.5.0%2B1.20.4.jar"
+url = "https://cdn.modrinth.com/data/5ZwdcRci/versions/KIhjQeSw/ImmediatelyFast-Fabric-1.5.2%2B1.20.4.jar"
 hash-format = "sha512"
-hash = "39984da8bd7daf0d71ddfb74b1a0ea6f60e8a332705b2d2342d1d0c4f8029f384bca43df7a3d6a6f999b2ac32e9d98f70b4907ce29cfcf02a00a3ece5a7538b9"
+hash = "076be155faed4ad977b4df2e8e36176b53cac11ad221fc1b1cf79d14a9b13d7102d0a52c64d1870dd356df5d34f491c1cc3a1ef01e979ddd9b34ccd003cc2119"
 
 [update]
 [update.modrinth]
 mod-id = "5ZwdcRci"
-version = "6QvRWWbF"
+version = "KIhjQeSw"

--- a/pack/mods/itemphysic.pw.toml
+++ b/pack/mods/itemphysic.pw.toml
@@ -1,13 +1,13 @@
 name = "ItemPhysic"
-filename = "ItemPhysic_FABRIC_v1.8.7_mc1.20.1.jar"
+filename = "ItemPhysic_FABRIC_v1.8.9_mc1.20.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/aT8BzaOj/versions/VpF30ZvW/ItemPhysic_FABRIC_v1.8.7_mc1.20.1.jar"
+url = "https://cdn.modrinth.com/data/aT8BzaOj/versions/PxwVRwDN/ItemPhysic_FABRIC_v1.8.9_mc1.20.1.jar"
 hash-format = "sha512"
-hash = "0b87aafc3fe7d1635ba1fbe210f845d604b61bc533f03f0efe95c5709436c77dee85833629fbd9a56b55e4766020e415289b961e2fc9ae59d0e8b272abb16270"
+hash = "51a89d886f3e12a7227db6caef8a6d2bcdb1c8f240d019b7f46682fa032ba67f4b57bc043770cefa7b51629fa2f64a2ee1ff9d55b64bd4421efe2830a7c81c99"
 
 [update]
 [update.modrinth]
 mod-id = "aT8BzaOj"
-version = "VpF30ZvW"
+version = "PxwVRwDN"

--- a/pack/mods/jade-addons-fabric.pw.toml
+++ b/pack/mods/jade-addons-fabric.pw.toml
@@ -1,6 +1,7 @@
 name = "Jade Addons (Fabric)"
 filename = "JadeAddons-1.20.1-Fabric-5.4.0.jar"
 side = "both"
+pin = true
 
 [download]
 url = "https://cdn.modrinth.com/data/fThnVRli/versions/DSkzT8Ma/JadeAddons-1.20.1-Fabric-5.4.0.jar"

--- a/pack/mods/jei.pw.toml
+++ b/pack/mods/jei.pw.toml
@@ -1,13 +1,13 @@
 name = "Just Enough Items"
-filename = "jei-1.20.1-fabric-15.20.0.112.jar"
+filename = "jei-1.20.1-fabric-15.20.0.127.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/u6dRKJwZ/versions/MMnbcAih/jei-1.20.1-fabric-15.20.0.112.jar"
+url = "https://cdn.modrinth.com/data/u6dRKJwZ/versions/vcirZJi7/jei-1.20.1-fabric-15.20.0.127.jar"
 hash-format = "sha512"
-hash = "c13fbab6764aec7f8f29eace23592aeabaf2adf1aa03af73e996aeceb2d553485fa94b6162874464bb3ab41e70f3448ed2c42553eecbcaefa682f0fa015dcae4"
+hash = "209f3eea5f2e620d437008eb1b0d27f0ce6764932b1a973a5cf7acd404a40f2e711f8111fcebad9ea87cbc54935bd1b95ab585e5934a371cadc55606330d1af8"
 
 [update]
 [update.modrinth]
 mod-id = "u6dRKJwZ"
-version = "MMnbcAih"
+version = "vcirZJi7"

--- a/pack/mods/justenoughbreeding.pw.toml
+++ b/pack/mods/justenoughbreeding.pw.toml
@@ -1,13 +1,13 @@
 name = "Just Enough Breeding (JEBr)"
-filename = "justenoughbreeding-fabric-1.20-1.20.1-1.5.0.jar"
+filename = "justenoughbreeding-fabric-1.20-1.20.1-2.3.0.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/9Pk89J3g/versions/bIwMGq4U/justenoughbreeding-fabric-1.20-1.20.1-1.5.0.jar"
+url = "https://cdn.modrinth.com/data/9Pk89J3g/versions/lejsdij0/justenoughbreeding-fabric-1.20-1.20.1-2.3.0.jar"
 hash-format = "sha512"
-hash = "e4ee127601ff19fd523b63262adfec997db8b2c702a2cc4df68e9667cb3df7ea202a48e2950c79237f1c0da9d48e6c4ffc94a8cb24aae1bba566b71aa92db442"
+hash = "6ef804f2817d35252ac7fddbb5a68c4e6c888d555a5e3dc2875173a3eb66dca7ffe55a2ef5ba525cfb42420dc4ac29f790a39d8a5e8951a918027d18bdaa0c57"
 
 [update]
 [update.modrinth]
 mod-id = "9Pk89J3g"
-version = "bIwMGq4U"
+version = "lejsdij0"

--- a/pack/mods/lambdynamiclights.pw.toml
+++ b/pack/mods/lambdynamiclights.pw.toml
@@ -1,13 +1,13 @@
 name = "LambDynamicLights"
-filename = "lambdynamiclights-4.1.3+1.20.1.jar"
+filename = "lambdynamiclights-4.4.0+1.20.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/yBW8D80W/versions/Zxi6kGDV/lambdynamiclights-4.1.3%2B1.20.1.jar"
+url = "https://cdn.modrinth.com/data/yBW8D80W/versions/AQfTnYyJ/lambdynamiclights-4.4.0%2B1.20.1.jar"
 hash-format = "sha512"
-hash = "f1fc41c4c99df4fe6eea97070dc8b54a28830fa6a6b33f33833f25741babfe38d12a2bdcae5ccc4b5a115a427d46e22e2487431e23d86080efad3a2f571a1831"
+hash = "65f297e32ba3a72537b22730dfbe8dac9ce1ba33e62c2ddf85302b8a5131dd1fe92cca151673599c0b6adeb4ec5bd254f2cfdde66c3ca909f08e9319ebfacb56"
 
 [update]
 [update.modrinth]
 mod-id = "yBW8D80W"
-version = "Zxi6kGDV"
+version = "AQfTnYyJ"

--- a/pack/mods/lets-do-addon-compat.pw.toml
+++ b/pack/mods/lets-do-addon-compat.pw.toml
@@ -1,13 +1,13 @@
 name = "[Let's Do Addon] Compat"
-filename = "letsdocompat-fabric-2.2.3.jar"
+filename = "letsdocompat-fabric-2.2.4.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/FNi5IMiX/versions/mNZaKLS0/letsdocompat-fabric-2.2.3.jar"
+url = "https://cdn.modrinth.com/data/FNi5IMiX/versions/8la3SE7N/letsdocompat-fabric-2.2.4.jar"
 hash-format = "sha512"
-hash = "8cff987eaace2e6f735a17acdd08b7150ec21104eb0e7b1d29af15c708271bde81d2e231ca30d09d869f7e6296772023ba9d78a0c28b2278862feafbe8e6d4f5"
+hash = "ca79014e0aace5323cab2f264d40cfbdc52827a74249eca7dede77f70022c16aa2b16ff7a3c8619c5c467866247fa063c8fde9f53e94c04b87206957c7a0d2cc"
 
 [update]
 [update.modrinth]
 mod-id = "FNi5IMiX"
-version = "mNZaKLS0"
+version = "8la3SE7N"

--- a/pack/mods/lets-do-bakery-farmcharm-compat.pw.toml
+++ b/pack/mods/lets-do-bakery-farmcharm-compat.pw.toml
@@ -1,13 +1,13 @@
 name = "[Let's Do] Bakery - Farm&Charm Compat"
-filename = "letsdo-bakery-fabric-2.0.5.jar"
+filename = "letsdo-bakery-fabric-2.0.6.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/oNB5jhlA/versions/HnCM6bcy/letsdo-bakery-fabric-2.0.5.jar"
+url = "https://cdn.modrinth.com/data/oNB5jhlA/versions/KEv4JeEB/letsdo-bakery-fabric-2.0.6.jar"
 hash-format = "sha512"
-hash = "a5c5b4abc1a5d156dedf860808c0b172de0f4ef56b555fe3c0e862bc4bc2c897aa6193218e44b369d7ce8b3797ed06ad6344821138c2b66c136220ab8683a9b6"
+hash = "129d664e0e9e05eab2ea6e8aef27f7cf741ba419d90617e9943d2db254c73d549b0632a2ee821a3b80c4455d918773fc3becbb9019c2a572c9d727726de525ca"
 
 [update]
 [update.modrinth]
 mod-id = "oNB5jhlA"
-version = "HnCM6bcy"
+version = "KEv4JeEB"

--- a/pack/mods/lets-do-brewery-farmcharm-compat.pw.toml
+++ b/pack/mods/lets-do-brewery-farmcharm-compat.pw.toml
@@ -1,13 +1,13 @@
 name = "[Let's Do] Brewery - Farm&Charm Compat"
-filename = "letsdo-brewery-fabric-2.0.5.jar"
+filename = "letsdo-brewery-fabric-2.0.6.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/b7NV2plI/versions/5yxZCrX8/letsdo-brewery-fabric-2.0.5.jar"
+url = "https://cdn.modrinth.com/data/b7NV2plI/versions/W2QrBsrL/letsdo-brewery-fabric-2.0.6.jar"
 hash-format = "sha512"
-hash = "53721c0c898730a6bcc9921a6c599fff148983693f32f74167d7609ca0771b0e25ac33e32483e3df71129cf1e05eb74151e18f78b66063062e22a5b54a00cd0a"
+hash = "9fe9c809215874453f1f7d832975d0855b0d66e0b8b4933a4182aadeed52899b4b9c49680cd1a7325eefafe72541b3ba6b44e90ee4039b21a6a14ccc7afcff35"
 
 [update]
 [update.modrinth]
 mod-id = "b7NV2plI"
-version = "5yxZCrX8"
+version = "W2QrBsrL"

--- a/pack/mods/lets-do-candlelight-farmcharm-compat.pw.toml
+++ b/pack/mods/lets-do-candlelight-farmcharm-compat.pw.toml
@@ -1,13 +1,13 @@
 name = "[Let's Do] Candlelight - Farm&Charm compat"
-filename = "letsdo-candlelight-fabric-2.0.4.jar"
+filename = "letsdo-candlelight-fabric-2.0.5.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/qwbArkQk/versions/FdI5FhHe/letsdo-candlelight-fabric-2.0.4.jar"
+url = "https://cdn.modrinth.com/data/qwbArkQk/versions/RUk2PHO1/letsdo-candlelight-fabric-2.0.5.jar"
 hash-format = "sha512"
-hash = "20047cb75d7c88332ae4a703473dbe6da79a5303c52bc332acb9733ba2ff1f05005ebc07b74422921b395169b3b40c47721a5a87e2333026d7768bfbc763ec7b"
+hash = "6a2daf556a3f0a665d45e9ee560551e955d2e340dd05e5d778db8d371d320f9a629e4a813465d378e5ac9ca07e63b96a2eaaa01f3079dbc7455b274559497a56"
 
 [update]
 [update.modrinth]
 mod-id = "qwbArkQk"
-version = "FdI5FhHe"
+version = "RUk2PHO1"

--- a/pack/mods/lets-do-farm-charm.pw.toml
+++ b/pack/mods/lets-do-farm-charm.pw.toml
@@ -1,13 +1,13 @@
 name = "[Let's Do] Farm & Charm"
-filename = "letsdo-farm_and_charm-fabric-1.0.9.jar"
+filename = "letsdo-farm_and_charm-fabric-1.0.14.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/HJetCzWo/versions/Edsce9xz/letsdo-farm_and_charm-fabric-1.0.9.jar"
+url = "https://cdn.modrinth.com/data/HJetCzWo/versions/sMjnKy5B/letsdo-farm_and_charm-fabric-1.0.14.jar"
 hash-format = "sha512"
-hash = "ae0a7b6b8f2c410d2cf2ad6653932772bf1086a8a49394d2043ce7dcbcd85b243ee9347e53e71d864976b68b4ae2c1c2957337a25c2e6c2df94b008b0bb5b8c9"
+hash = "21ac172f64e88d4f942375bbcddae0a76bec483b15694f88bc816874434d4f385161b9a05e113da626159350a1e4806b3e4113121d6f170536f65a15f7fc661f"
 
 [update]
 [update.modrinth]
 mod-id = "HJetCzWo"
-version = "Edsce9xz"
+version = "sMjnKy5B"

--- a/pack/mods/lets-do-vinery.pw.toml
+++ b/pack/mods/lets-do-vinery.pw.toml
@@ -1,13 +1,13 @@
 name = "[Let's Do] Vinery"
-filename = "letsdo-vinery-fabric-1.4.39.jar"
+filename = "letsdo-vinery-fabric-1.4.41.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/1DWmBJVA/versions/WdjalkV8/letsdo-vinery-fabric-1.4.39.jar"
+url = "https://cdn.modrinth.com/data/1DWmBJVA/versions/Xv8zHKzi/letsdo-vinery-fabric-1.4.41.jar"
 hash-format = "sha512"
-hash = "8b6a55b9149531dfdde8a15391ff2aab568c5f1a49d0d837a4421ec23fe9f49a9bd4094ed19757cc98f4cec3c0c34d0248b116036b4e4ca765d284fe581fb7a0"
+hash = "b2af162ea4f41aefbdeed997777ac3080b43ae76b847344a4117ae69a0de579b3157ab0c3ccbdac89964d87f596aee3b79426ea2a89cad08a82a676f7fd68808"
 
 [update]
 [update.modrinth]
 mod-id = "1DWmBJVA"
-version = "WdjalkV8"
+version = "Xv8zHKzi"

--- a/pack/mods/lithium.pw.toml
+++ b/pack/mods/lithium.pw.toml
@@ -1,13 +1,13 @@
 name = "Lithium"
-filename = "lithium-fabric-mc1.20.1-0.11.3.jar"
+filename = "lithium-fabric-mc1.20.1-0.11.4.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/vuuAe7ZA/lithium-fabric-mc1.20.1-0.11.3.jar"
+url = "https://cdn.modrinth.com/data/gvQqBUqZ/versions/iEcXOkz4/lithium-fabric-mc1.20.1-0.11.4.jar"
 hash-format = "sha512"
-hash = "dc9bc65146f41cf99c46b46216dd3645be7c45cfeb2bc7cdceaa11bcd57771cdf2c30e84ce057f12b8dbf0d54fb808143cf46d92626370011ba5112bec18e720"
+hash = "31938b7e849609892ffa1710e41f2e163d11876f824452540658c4b53cd13c666dbdad8d200989461932bd9952814c5943e64252530c72bdd5d8641775151500"
 
 [update]
 [update.modrinth]
 mod-id = "gvQqBUqZ"
-version = "vuuAe7ZA"
+version = "iEcXOkz4"

--- a/pack/mods/lithostitched.pw.toml
+++ b/pack/mods/lithostitched.pw.toml
@@ -1,13 +1,13 @@
 name = "Lithostitched"
-filename = "lithostitched-fabric-1.20.1-1.4.10.jar"
+filename = "lithostitched-fabric-1.20.1-1.4.11.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/XaDC71GB/versions/owa0e2tu/lithostitched-fabric-1.20.1-1.4.10.jar"
+url = "https://cdn.modrinth.com/data/XaDC71GB/versions/9bbVphAR/lithostitched-fabric-1.20.1-1.4.11.jar"
 hash-format = "sha512"
-hash = "3163acc2a3d3fb8b1eb9c72e3d06d0dd2a9a262e87e4fd30b46079436710dd03db81500759688c4479e44cde69da12c9c826dd658de9f85ed03285e9950b03ac"
+hash = "d8e840907e3f7326c1e6605b65c46eb4e920e4790ab4074884ad21913f0c097dcacf4b813091239eb58bd65b7c75b96d04bb4df6eec830f89a21e217e3c0fdec"
 
 [update]
 [update.modrinth]
 mod-id = "XaDC71GB"
-version = "owa0e2tu"
+version = "9bbVphAR"

--- a/pack/mods/mes-moogs-end-structures.pw.toml
+++ b/pack/mods/mes-moogs-end-structures.pw.toml
@@ -1,13 +1,13 @@
 name = "MES - Moog's End Structures"
-filename = "mes-1.3.4-1.20-fabric.jar"
+filename = "mes-1.4.6-1.20-fabric.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/r4PuRGfV/versions/H58OIzws/mes-1.3.4-1.20-fabric.jar"
+url = "https://cdn.modrinth.com/data/r4PuRGfV/versions/44mt4wIf/mes-1.4.6-1.20-fabric.jar"
 hash-format = "sha512"
-hash = "3f4da2337c79ca4047b6d391eff303d8cd6990a2050a2af151f3dab6efa7601bb9bc1a6f1f5cbe3eb1a901e79811f9fa34de98649ed2b9bebb177622ca97a538"
+hash = "1a41fbc550e7fb68a42a47438466001992815efd62b672ba20f13404701b0fae3e2d16baa313e447b02e919f83dd9abfac38e072f45d9fb950dba2e25635f92a"
 
 [update]
 [update.modrinth]
 mod-id = "r4PuRGfV"
-version = "H58OIzws"
+version = "44mt4wIf"

--- a/pack/mods/mmmmmmmmmmmm.pw.toml
+++ b/pack/mods/mmmmmmmmmmmm.pw.toml
@@ -1,13 +1,13 @@
 name = "MmmMmmMmmMmm"
-filename = "dummmmmmy-1.20-2.0.7-fabric.jar"
+filename = "dummmmmmy-1.20-2.0.8-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/Adega8YN/versions/sHdoBLpl/dummmmmmy-1.20-2.0.7-fabric.jar"
+url = "https://cdn.modrinth.com/data/Adega8YN/versions/ARuuU3Qq/dummmmmmy-1.20-2.0.8-fabric.jar"
 hash-format = "sha512"
-hash = "356241ec457c0b11bf8a5fda56a15bb4620824e6b42dfd67483ac5e7139261fde22acf9fdea406dd30daec900460864862e5f98089ccf880d3a45038f3ec8b58"
+hash = "15f88a31e359c4bfa71a347440449b696c002f49b996832fa652ea8a65447344a543842753c61568eee959c5ff95d987cf4c079f879e5b5e03f096498fe2763b"
 
 [update]
 [update.modrinth]
 mod-id = "Adega8YN"
-version = "sHdoBLpl"
+version = "ARuuU3Qq"

--- a/pack/mods/mns-moogs-nether-structures.pw.toml
+++ b/pack/mods/mns-moogs-nether-structures.pw.toml
@@ -1,13 +1,13 @@
 name = "MNS - Moog's Nether Structures"
-filename = "mns-1.0.1-1.20-fabric.jar"
+filename = "MoogsNetherStructures-1.20-2.0.2.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/nGUXvjTa/versions/PTf5Y56P/mns-1.0.1-1.20-fabric.jar"
+url = "https://cdn.modrinth.com/data/nGUXvjTa/versions/PE6U39hM/MoogsNetherStructures-1.20-2.0.2.jar"
 hash-format = "sha512"
-hash = "fbef2ed5e5c7bca85b8bab242c84a0d3dbc72335318c8df9d696aa52617d9fb28a8396a3fecf9554e8aa265a157eee232f7d6e1bc7235c04c89ee3a1695f4abe"
+hash = "3a49b5480c5f9b9c0a5f4e43b060841c0706ccb8341dacc598e9c22688ce9f54e931401aa213e6db6ded7bcdcc9396d89933ead715ccce2d98e4725e5f4f7a11"
 
 [update]
 [update.modrinth]
 mod-id = "nGUXvjTa"
-version = "PTf5Y56P"
+version = "PE6U39hM"

--- a/pack/mods/modernfix.pw.toml
+++ b/pack/mods/modernfix.pw.toml
@@ -1,13 +1,13 @@
 name = "ModernFix"
-filename = "modernfix-fabric-5.24.0+mc1.20.1.jar"
+filename = "modernfix-fabric-5.25.1+mc1.20.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/nmDcB62a/versions/dJyYiSPP/modernfix-fabric-5.24.0%2Bmc1.20.1.jar"
+url = "https://cdn.modrinth.com/data/nmDcB62a/versions/fLFjab2A/modernfix-fabric-5.25.1%2Bmc1.20.1.jar"
 hash-format = "sha512"
-hash = "df37e61ef62a0b8e7146c32894c2e215c55074225f9f48e70f41584554403caf82bb4d9f625fdf9098dba3e06a10f9c937bede8dfee0cf77663827d99932f906"
+hash = "a63185fea9c4afd1b966a82b6e62852e62e8c32cfe7864fab0ae7343a98994529a2009d72477215ff5fedd473a4f0684bd455f068c46a89b90bd007ff3860e73"
 
 [update]
 [update.modrinth]
 mod-id = "nmDcB62a"
-version = "dJyYiSPP"
+version = "fLFjab2A"

--- a/pack/mods/moogs-structure-lib.pw.toml
+++ b/pack/mods/moogs-structure-lib.pw.toml
@@ -1,0 +1,13 @@
+name = "Moog's Structure Lib (moogs_structures)"
+filename = "moogs_structure_lib-1.1.0-1.20-1.20.4-fabric.jar"
+side = "server"
+
+[download]
+url = "https://cdn.modrinth.com/data/1oUDhxuy/versions/rxsrpzbh/moogs_structure_lib-1.1.0-1.20-1.20.4-fabric.jar"
+hash-format = "sha512"
+hash = "0cf42d7103f783b686bd0920d03792a849a5ff11241e8d70ac2ccb3423f4bc2d6ba4426bc13783d0f06f3fe50cba4132852cb1875247787b876517560852d9fb"
+
+[update]
+[update.modrinth]
+mod-id = "1oUDhxuy"
+version = "rxsrpzbh"

--- a/pack/mods/moogs-voyager-structures.pw.toml
+++ b/pack/mods/moogs-voyager-structures.pw.toml
@@ -1,13 +1,13 @@
 name = "MVS - Moog's Voyager Structures"
-filename = "mvs-4.1.5-1.20.jar"
+filename = "MoogsVoyagerStructures-1.20-5.0.21.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/OQAgZMH1/versions/OQH5doaL/mvs-4.1.5-1.20.jar"
+url = "https://cdn.modrinth.com/data/OQAgZMH1/versions/3jEMNi1E/MoogsVoyagerStructures-1.20-5.0.21.jar"
 hash-format = "sha512"
-hash = "4228ce79cd3caa59407112847fb8f8f804848a179108bd0818eec73afb81a9a38688d34ec0b09f8b5cdd8dea5cbfaf9e64697f13018dc4acae85b22b7a25c918"
+hash = "e5124101ca9eec0dd45c9092aee8a939b02bb76be2b02df07fecb0e6a3577ddce58f38f61dd361db904ad69009678f0772fdf400e1b6df708d5177ca04e391fc"
 
 [update]
 [update.modrinth]
 mod-id = "OQAgZMH1"
-version = "OQH5doaL"
+version = "3jEMNi1E"

--- a/pack/mods/moonlight.pw.toml
+++ b/pack/mods/moonlight.pw.toml
@@ -1,13 +1,13 @@
 name = "Moonlight Lib"
-filename = "moonlight-1.20-2.14.11-fabric.jar"
+filename = "moonlight-1.20-2.16.16-fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/twkfQtEc/versions/GVVbixH6/moonlight-1.20-2.14.11-fabric.jar"
+url = "https://cdn.modrinth.com/data/twkfQtEc/versions/1yJlkP4n/moonlight-1.20-2.16.16-fabric.jar"
 hash-format = "sha512"
-hash = "0c0bb8cde5b72bcb6075151d0cd1f6f92dff9d36bb05d2011990ecb25c6d7082892e278ec47de7cb94d729b863e75bab653c6f86cf9f2b5480ed7b163aaf4275"
+hash = "007d918889a84d9d3a40b503bce48fa73cb446bd08b29da73578426dbb2dee4552cc191fe772e4f40bcaf2a3165980a02e7660f0438a2742af06700eb4bb4069"
 
 [update]
 [update.modrinth]
 mod-id = "twkfQtEc"
-version = "GVVbixH6"
+version = "1yJlkP4n"

--- a/pack/mods/ping-wheel.pw.toml
+++ b/pack/mods/ping-wheel.pw.toml
@@ -1,13 +1,13 @@
 name = "Ping Wheel"
-filename = "Ping-Wheel-1.10.3-fabric-1.20.1.jar"
+filename = "Ping-Wheel-1.12.0-fabric-1.20.1.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/QQXAdCzh/versions/57oiW0gw/Ping-Wheel-1.10.3-fabric-1.20.1.jar"
+url = "https://cdn.modrinth.com/data/QQXAdCzh/versions/ZtRGFjI1/Ping-Wheel-1.12.0-fabric-1.20.1.jar"
 hash-format = "sha512"
-hash = "e50ab2be4f05e9d621a98c3994a9b20254eca6ca06715dc05c187e9fb9eff9f17ad2d6b334e2be627d37faddbe13886a5037e0be8148cd9a54fb7a5803d5b09c"
+hash = "e19138630284edc113032812431b755fccd6de19cd325e79cf5ad97fc0c9e3516ed3de0ccbeb3889aa49d58b753f4ee2ee5e22081a631c2cb48ea34a9c3dd887"
 
 [update]
 [update.modrinth]
 mod-id = "QQXAdCzh"
-version = "57oiW0gw"
+version = "ZtRGFjI1"

--- a/pack/mods/puzzles-lib.pw.toml
+++ b/pack/mods/puzzles-lib.pw.toml
@@ -1,13 +1,13 @@
 name = "Puzzles Lib"
-filename = "PuzzlesLib-v8.1.32-1.20.1-Fabric.jar"
+filename = "PuzzlesLib-v8.1.33-1.20.1-Fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/QAGBst4M/versions/RbcWdHr1/PuzzlesLib-v8.1.32-1.20.1-Fabric.jar"
+url = "https://cdn.modrinth.com/data/QAGBst4M/versions/N8gFdljq/PuzzlesLib-v8.1.33-1.20.1-Fabric.jar"
 hash-format = "sha512"
-hash = "340f5ee637a8a35b2ce66b2fda0b2e829e58b8dcc445856a7635f4f77ad79c894a38ee26c259d46c3973b72b8593eb25b07d8484d2ab8bebe1dab949f15cf454"
+hash = "86e57fcf41a1b1f6f33375a10e3eba5c78b7e634b5c694d9082e7f56f77aa6339a5d0bbfe4e50978154e3246a70d5a4a7b6570b56fd70ae41033f870de3178d2"
 
 [update]
 [update.modrinth]
 mod-id = "QAGBst4M"
-version = "RbcWdHr1"
+version = "N8gFdljq"

--- a/pack/mods/repurposed-structures-fabric.pw.toml
+++ b/pack/mods/repurposed-structures-fabric.pw.toml
@@ -1,13 +1,13 @@
 name = "Repurposed Structures - Quilt/Fabric"
-filename = "repurposed_structures-7.1.18+1.20.1-fabric.jar"
+filename = "repurposed_structures-7.1.19+1.20.1-fabric.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/muf0XoRe/versions/Q88icklM/repurposed_structures-7.1.18%2B1.20.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/muf0XoRe/versions/Dt9OIvgm/repurposed_structures-7.1.19%2B1.20.1-fabric.jar"
 hash-format = "sha512"
-hash = "9005101dda9828a98a099d4ec8fa58dc5cbee931db8cccf5693de149963dacc78a5e06144389bc540cc3a0f7c2228c66f602ec6badd29b76de26d526ba642280"
+hash = "8d0187f35dc6727d34427f1e7a77918022dea1dddaafaef3ed6438bf95d9ba5adfbb837073aecd50e09bfd7f1d05994104d71d1b175870fb0da2455219bf7c48"
 
 [update]
 [update.modrinth]
 mod-id = "muf0XoRe"
-version = "Q88icklM"
+version = "Dt9OIvgm"

--- a/pack/mods/shifting-wares.pw.toml
+++ b/pack/mods/shifting-wares.pw.toml
@@ -1,13 +1,13 @@
 name = "Shifting Wares"
-filename = "shifting-wares-2.1.2+1.20.2.jar"
+filename = "shifting-wares-3.1.1+1.20.2.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/jD7tenmB/versions/zQg0NK7w/shifting-wares-2.1.2%2B1.20.2.jar"
+url = "https://cdn.modrinth.com/data/jD7tenmB/versions/FDCm5zcS/shifting-wares-3.1.1%2B1.20.2.jar"
 hash-format = "sha512"
-hash = "b0539a7204843523364fd29bd51b9d42df345a167c4faff99d51eee8568e585109307f9c40d73c236f6f774145fd4540f02a2992044178c99aa25b53e8578acc"
+hash = "8e8b5bebf0a7dfc10f4586ec40368742541aba22ccb859c739009d56e9ee4a5ce88f59f4b25becb1e7b9eb5b064bcf78b90e3da9ca75d9334e3ae665b7f2f947"
 
 [update]
 [update.modrinth]
 mod-id = "jD7tenmB"
-version = "zQg0NK7w"
+version = "FDCm5zcS"

--- a/pack/mods/simple-voice-chat.pw.toml
+++ b/pack/mods/simple-voice-chat.pw.toml
@@ -1,13 +1,13 @@
 name = "Simple Voice Chat"
-filename = "voicechat-fabric-1.20.1-2.5.33.jar"
+filename = "voicechat-fabric-1.20.1-2.6.6.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/9eGKb6K1/versions/2jq9fB3a/voicechat-fabric-1.20.1-2.5.33.jar"
+url = "https://cdn.modrinth.com/data/9eGKb6K1/versions/FA95tUXq/voicechat-fabric-1.20.1-2.6.6.jar"
 hash-format = "sha512"
-hash = "a4ea8ab4a87bc744d920a6631ba6cb7cb5e8f3f09e96add95ab2662d6953320fe73ecf546fcf98337090df6f1b5adfe4ce5fc388805c9be2e8a9e19d210e67f5"
+hash = "571227a51a33803649c0e166c46b231dd07639503a045c7304e7b0f40260f339136d19cfbd8f718fd79a185dfd15a26452bf13df55d09d431a09b7c1ac9c2cc9"
 
 [update]
 [update.modrinth]
 mod-id = "9eGKb6K1"
-version = "2jq9fB3a"
+version = "FA95tUXq"

--- a/pack/mods/skinrestorer.pw.toml
+++ b/pack/mods/skinrestorer.pw.toml
@@ -1,13 +1,13 @@
 name = "Skin Restorer"
-filename = "skinrestorer-2.3.5+1.20-fabric.jar"
+filename = "skinrestorer-2.4.3+1.20-fabric.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/ghrZDhGW/versions/VunOV4F2/skinrestorer-2.3.5%2B1.20-fabric.jar"
+url = "https://cdn.modrinth.com/data/ghrZDhGW/versions/vOQRWGz7/skinrestorer-2.4.3%2B1.20-fabric.jar"
 hash-format = "sha512"
-hash = "abca26fd423d2d70b5f8ef3abdb3f0065ed7dab53701d7b0c48084ffe7e189f6db4af5a5495427dddaab430df0c3eb9a0a5da1789ba204488c16e54be7416aed"
+hash = "850ee69db48c4cc90e8f7edd4b1cf87ab195b97d09118a5654c0665fc575dabe665eb4753ad8718ddc05709a2d870e414d8bdedf88714ef02d7a1cfb973879c3"
 
 [update]
 [update.modrinth]
 mod-id = "ghrZDhGW"
-version = "VunOV4F2"
+version = "vOQRWGz7"

--- a/pack/mods/sound-physics-remastered.pw.toml
+++ b/pack/mods/sound-physics-remastered.pw.toml
@@ -1,13 +1,13 @@
 name = "Sound Physics Remastered"
-filename = "sound-physics-remastered-fabric-1.20.1-1.4.12.jar"
+filename = "sound-physics-remastered-fabric-1.20.1-1.5.1.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/qyVF9oeo/versions/LrmG4rhi/sound-physics-remastered-fabric-1.20.1-1.4.12.jar"
+url = "https://cdn.modrinth.com/data/qyVF9oeo/versions/sCsWXt85/sound-physics-remastered-fabric-1.20.1-1.5.1.jar"
 hash-format = "sha512"
-hash = "d1719cb99b9f6b239ce0d02527be0d30172b208eed31737a45216f1151b7a1666503747d160dc38ffa6abe579d5f4905f261cafc8e150e4fe1f903505b201b26"
+hash = "3889b1e8e5448b36321a63b631cba89fe4b519f05fe85c572e4bc891216d12d55381f139b7a1cd53e210bddfee7750882506a4b71508da585cf4b459605d80cb"
 
 [update]
 [update.modrinth]
 mod-id = "qyVF9oeo"
-version = "LrmG4rhi"
+version = "sCsWXt85"

--- a/pack/mods/the-lost-castle.pw.toml
+++ b/pack/mods/the-lost-castle.pw.toml
@@ -1,13 +1,13 @@
 name = "The Lost Castle"
-filename = "tlc-fabric-1.0.1-1.20.X.jar"
+filename = "tlc-fabric-1.20.X-1.2.0-eyeSpy.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/FGlHZl7X/versions/r1kI9nMD/tlc-fabric-1.0.1-1.20.X.jar"
+url = "https://cdn.modrinth.com/data/FGlHZl7X/versions/9B9A85bd/tlc-fabric-1.20.X-1.2.0-eyeSpy.jar"
 hash-format = "sha512"
-hash = "17a2e32bbe873acf4ba2f15473cd03cb6362200317af7e842caaca9bd86efb2836ebaead1cdf03904df9d785ff6758926e7b4c3285995b4749fa4d15b1da67a3"
+hash = "89dd6610799468bd068d20a92ecc42c4bd41619c2724db0c5e71a37bc81dd609268b04a2d47d7bec4f89c4fae9c0b94c0b2c6c03ed0f224d8680e88db79ad1a8"
 
 [update]
 [update.modrinth]
 mod-id = "FGlHZl7X"
-version = "r1kI9nMD"
+version = "9B9A85bd"

--- a/pack/mods/tide.pw.toml
+++ b/pack/mods/tide.pw.toml
@@ -1,13 +1,13 @@
 name = "Tide"
-filename = "tide-fabric-1.20.1-1.6.2.jar"
+filename = "tide-fabric-1.20.1-1.6.5.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/die1AF7i/versions/F0RjP8Vr/tide-fabric-1.20.1-1.6.2.jar"
+url = "https://cdn.modrinth.com/data/die1AF7i/versions/qLC5xfu5/tide-fabric-1.20.1-1.6.5.jar"
 hash-format = "sha512"
-hash = "8bd36ebcc651c8febda093d5f2479e36ffa600fd2c382c9af0228241209ee1a9666e22f3431fd13baafaf42f2aa2a28973515f9879cfef0bfe6e3390492e5bc0"
+hash = "c6393780b5d33fe0a0c17a6e594a1911fe56c0449b1ba252e81037f2c6f4b5f59ecbd3e0850cc18fd70c1e90263c3b1e6966461fa00cef0f6deba7e4fd8dfa9a"
 
 [update]
 [update.modrinth]
 mod-id = "die1AF7i"
-version = "F0RjP8Vr"
+version = "qLC5xfu5"

--- a/pack/mods/unilib.pw.toml
+++ b/pack/mods/unilib.pw.toml
@@ -1,13 +1,13 @@
 name = "UniLib"
-filename = "UniLib-1.1.0+1.20.1-fabric.jar"
+filename = "UniLib-1.2.0+1.20.1-fabric.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/nT86WUER/versions/vZrLmFy5/UniLib-1.1.0%2B1.20.1-fabric.jar"
+url = "https://cdn.modrinth.com/data/nT86WUER/versions/lLMXWG7j/UniLib-1.2.0%2B1.20.1-fabric.jar"
 hash-format = "sha512"
-hash = "f9ee3423c9925ae60b5191a3a134324f9acad1a072d15ea2d5ab9f00436299a9a7669c66936983f384f6c866149a571d21273828dc8a641f8ab89b4ed7d121ef"
+hash = "785dfe846c64c79803251e835c8ff6bb4dca19bff9bf179be9ac23d7358808ec64ede30faf1dd339a1ba19d7b8cb2bb212040b4067a3420ced46548374aad892"
 
 [update]
 [update.modrinth]
 mod-id = "nT86WUER"
-version = "vZrLmFy5"
+version = "lLMXWG7j"

--- a/pack/mods/unnamed-desert.pw.toml
+++ b/pack/mods/unnamed-desert.pw.toml
@@ -1,13 +1,13 @@
 name = "Unnamed Desert"
-filename = "u_desert-1.6.1+mc1.19-1.21.6.jar"
+filename = "u_desert-1.6.3+mc1.19-1.21.8.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/ThFWvdF1/versions/GQm6cObh/u_desert-1.6.1%2Bmc1.19-1.21.6.jar"
+url = "https://cdn.modrinth.com/data/ThFWvdF1/versions/ITNSCuzL/u_desert-1.6.3%2Bmc1.19-1.21.8.jar"
 hash-format = "sha512"
-hash = "f83439cfc7c41142aefcdc783e51b21c8b62b5fa65aecf47f248851322145b7b9e0f4c21c9d9d95d1a467ad317f9fa6fe7a26fffab728bb220a92eec2fa1a38e"
+hash = "7da7e225974872a49aaa47a52872d23ffb0c35d5869ba680186ca1a6fc70e949fc09836795f9bd5ea1fa8bcd6cb08cffb7b39a3f82febc642a9f1c35f2c3faf0"
 
 [update]
 [update.modrinth]
 mod-id = "ThFWvdF1"
-version = "GQm6cObh"
+version = "ITNSCuzL"

--- a/pack/mods/visual-workbench.pw.toml
+++ b/pack/mods/visual-workbench.pw.toml
@@ -1,13 +1,13 @@
 name = "Visual Workbench"
-filename = "VisualWorkbench-v8.0.0-1.20.1-Fabric.jar"
+filename = "VisualWorkbench-v8.0.1-1.20.1-Fabric.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/kfqD1JRw/versions/vhuwOiNO/VisualWorkbench-v8.0.0-1.20.1-Fabric.jar"
+url = "https://cdn.modrinth.com/data/kfqD1JRw/versions/NP7AXO6Q/VisualWorkbench-v8.0.1-1.20.1-Fabric.jar"
 hash-format = "sha512"
-hash = "4f72d41398adeff00ae6228088fe2540668711b432b36e8f7e24c0dcdbca9a233974e194feab29154cd3fcd941aa977b10b82d8dfb7205f42e3d7d209a224485"
+hash = "55c0846886cc363703f09aca74e1c4b540aa04f38824893ffc66fe4db308fcb9c3af224edbe64585251c356f2a72132d6448b7ad827cff35849f3b9331a5d7af"
 
 [update]
 [update.modrinth]
 mod-id = "kfqD1JRw"
-version = "vhuwOiNO"
+version = "NP7AXO6Q"

--- a/pack/mods/waterframes.pw.toml
+++ b/pack/mods/waterframes.pw.toml
@@ -1,6 +1,7 @@
 name = "WATERFrAMES: Multimedia Displays"
 filename = "waterframes-FABRIC-mc1.20.1-v2.1.12c.jar"
 side = "both"
+pin = true
 
 [download]
 url = "https://cdn.modrinth.com/data/eBzFuVTM/versions/OIroJuKI/waterframes-FABRIC-mc1.20.1-v2.1.12c.jar"

--- a/pack/mods/watermedia.pw.toml
+++ b/pack/mods/watermedia.pw.toml
@@ -1,6 +1,7 @@
 name = "WATERMeDIA"
 filename = "watermedia-2.1.25.jar"
 side = "client"
+pin = true
 
 [download]
 url = "https://cdn.modrinth.com/data/G922NeHS/versions/8MrS6vpH/watermedia-2.1.25.jar"

--- a/pack/mods/xaeros-minimap.pw.toml
+++ b/pack/mods/xaeros-minimap.pw.toml
@@ -1,13 +1,13 @@
 name = "Xaero's Minimap"
-filename = "Xaeros_Minimap_25.2.6_Fabric_1.20.jar"
+filename = "Xaeros_Minimap_25.2.10_Fabric_1.20.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/1bokaNcj/versions/ePRxT2Wj/Xaeros_Minimap_25.2.6_Fabric_1.20.jar"
+url = "https://cdn.modrinth.com/data/1bokaNcj/versions/1Knv1cKY/Xaeros_Minimap_25.2.10_Fabric_1.20.jar"
 hash-format = "sha512"
-hash = "eca26f5dda06a5c42a8790261a37e894c650e77aa2b51ca6f201a967dcbc61856971c68db65ffb6295ac2651e12a00d9bac1d8b9133c8e9ce67dfbdd1b786b0e"
+hash = "5a0df7750c5b8f2a97e8756a42fc90ba8242b615d92a19e8f6ee7fdfc7dbc168806a30232971a8b39691ad8a97c7a8a112b99a1b2a8277d9b10b0cf9338a6cae"
 
 [update]
 [update.modrinth]
 mod-id = "1bokaNcj"
-version = "ePRxT2Wj"
+version = "1Knv1cKY"

--- a/pack/mods/xaeros-world-map.pw.toml
+++ b/pack/mods/xaeros-world-map.pw.toml
@@ -1,13 +1,13 @@
 name = "Xaero's World Map"
-filename = "XaerosWorldMap_1.39.9_Fabric_1.20.jar"
+filename = "XaerosWorldMap_1.39.12_Fabric_1.20.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/NcUtCpym/versions/fQpXYWtL/XaerosWorldMap_1.39.9_Fabric_1.20.jar"
+url = "https://cdn.modrinth.com/data/NcUtCpym/versions/XBgSFzXh/XaerosWorldMap_1.39.12_Fabric_1.20.jar"
 hash-format = "sha512"
-hash = "d10acb6ba4fa104372ad98baff2734bd98622ab3396a751a77c204efd349b73bf4044af4c65a62e92cbe14ee073d5424e1985776e4310968037e84543e336705"
+hash = "f84a3f3d1794a6da7ab96ea7ac08ab776df6a3f51f4fc02dc49fb5ef57518eb02cee308805622e71b383f195749c41b3bb33ea1ec252893f26ec89accf7fb854"
 
 [update]
 [update.modrinth]
 mod-id = "NcUtCpym"
-version = "fQpXYWtL"
+version = "XBgSFzXh"

--- a/pack/mods/yes-steve-model.pw.toml
+++ b/pack/mods/yes-steve-model.pw.toml
@@ -1,13 +1,13 @@
 name = "Yes Steve Model"
-filename = "yesstevemodel-fabric-1.20-2.4.1-release.jar"
+filename = "ysm-2.5.3-fabric+mc1.20.1-release.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/86xjpqqS/versions/65oFvzwY/yesstevemodel-fabric-1.20-2.4.1-release.jar"
+url = "https://cdn.modrinth.com/data/86xjpqqS/versions/2dRDUBnW/ysm-2.5.3-fabric%2Bmc1.20.1-release.jar"
 hash-format = "sha512"
-hash = "278f4d1d5f0ca33323b587a6b3e3be9bedbd3b26e46503ff9d2747a3b38656da1c1e0ddef979f2ed7c93035a02755973dac8d292b04536c76054d0f692f3243b"
+hash = "5a87bd069e76a0a3d859748a0e6b5d13f7173328c0f3ccff5032cba0fe425b02d4e701c3a5eb68a7646144eef808e7e00933c254b261de4526d97acb6272bfc9"
 
 [update]
 [update.modrinth]
 mod-id = "86xjpqqS"
-version = "65oFvzwY"
+version = "2dRDUBnW"

--- a/pack/mods/your-reputation.pw.toml
+++ b/pack/mods/your-reputation.pw.toml
@@ -1,6 +1,7 @@
 name = "Your Reputation"
 filename = "your-reputation-0.2.4+jade.1.20.jar"
 side = "both"
+pin = true
 
 [download]
 url = "https://cdn.modrinth.com/data/MrLyhFlg/versions/gDiKwohD/your-reputation-0.2.4%2Bjade.1.20.jar"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -9,7 +9,7 @@ hash-format = "sha256"
 hash = "2dbe4a52f131cb2d2a6a5842f5812c15682c166ae9aaa3e3ba39d55ce4f0f26a"
 
 [versions]
-fabric = "0.16.14"
+fabric = "0.18.1"
 minecraft = "1.20.1"
 unsup = "1.1.4"
 

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -1,6 +1,6 @@
 name = "Sekai Survival Modded"
 author = "Lutfilah Dzaky"
-version = "1.3.2"
+version = "1.3.3"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "2dbe4a52f131cb2d2a6a5842f5812c15682c166ae9aaa3e3ba39d55ce4f0f26a"
+hash = "24b5a3c1552b22ad2fa7892e25089cdd7e593bf80041f3b0743f8a5f68810d5c"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "24b5a3c1552b22ad2fa7892e25089cdd7e593bf80041f3b0743f8a5f68810d5c"
+hash = "af3d2739f127c6be1d82c357bc363ced697227082cf3b7c4a275841e98c71f79"
 
 [versions]
 fabric = "0.18.1"


### PR DESCRIPTION
Update the fabric version and multiple mods to their latest releases for improved compatibility, stability, and access to new features. Add a new dependency for Moog's structures mods and pin several dependencies to ensure compatibility.