### PR TITLE
Add configuration files for Create mod and update compatibility

### DIFF
--- a/pack/client-files/config/moreculling.toml
+++ b/pack/client-files/config/moreculling.toml
@@ -1,4 +1,5 @@
 [modCompatibility]
 copycats = false
 create = false
+createrailwaysnavigator = false
 pantographsandwires = false

--- a/pack/config/create-client.toml
+++ b/pack/config/create-client.toml
@@ -1,0 +1,2 @@
+[client]
+	maximumContraptionLightVolume = 65536

--- a/pack/config/create-server.toml
+++ b/pack/config/create-server.toml
@@ -1,0 +1,17 @@
+[trains]
+	maxTrackPlacementLength = 128
+	manualTrainSpeedModifier = 1
+	[trains.trainStats]
+        # 130 km/h = 36.1111 m/s
+		trainTopSpeed = 36.1111
+        # 65 km/h = 18.0556 m/s
+		trainTurningTopSpeed = 18.0556
+        # 3 km/h = 0.833 m/s
+		trainAcceleration = 0.83
+	[trains.poweredTrainStats]
+        # 360 km/h = 100 m/s
+		poweredTrainTopSpeed = 100.0
+        # 300 km/h = 83.3333 m/s
+		poweredTrainTurningTopSpeed = 83.3333
+        # 2.6 km/h × 0.27778 = 0.72 m/s
+		poweredTrainAcceleration = 0.72

--- a/pack/config/moreculling.pw.toml
+++ b/pack/config/moreculling.pw.toml
@@ -5,4 +5,4 @@ side = "client"
 [download]
 url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/config/moreculling.toml"
 hash-format = "sha512"
-hash = "413ca462278df1bbb63ea6b5a60837759050dece6a24dae07b498374a137c5144e7f12cb7015a9b48be7ec4fcaf7663d629af2fb63886d7c8003747893213bea"
+hash = "58cf024a4931dd373df5fadfef3aff0bcbdcf070b37e8a67bd5f984f47713181c2b22b43ed3b826b520dff978fac8b7b138abbba5cb253daea6af4b2a4e65f18"

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -11,6 +11,14 @@ hash = "138c13e753b15feae87016905206d8807d106aa48416cae491f04a9cec1aac73"
 metafile = true
 
 [[files]]
+file = "config/create-client.toml"
+hash = "4877aee40f7e40299b9756f638482fd30d3c0ef632bfbf443f8805157b5d5bf7"
+
+[[files]]
+file = "config/create-server.toml"
+hash = "db035283717017bcfb594b0baac1139fc5792d3f51af5ba9b9dabc92b1573284"
+
+[[files]]
 file = "config/enhanced_bes.pw.toml"
 hash = "d31d883e8625aa09dfe0e8f6b665557cee1cc1edb54fbfdb07adcd19c694f0d2"
 metafile = true

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -35,7 +35,7 @@ metafile = true
 
 [[files]]
 file = "config/moreculling.pw.toml"
-hash = "2f02b52477335a9e7f19d8ad740e175d74a7b4d8964aed6e768c7b154d5cba90"
+hash = "8677ddfd288d1f9969a4885aeef0a701aee613fa2ec79bc448520c458ce131e8"
 metafile = true
 
 [[files]]

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f5d70e38aafd55c199d5a53d381ba511bb9a5366c6fa51500f5694e3b2b86190"
+hash = "11e9fc026b38474cc450e42c5ea58db59bdcd6aa76944118155e51e876b3406f"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -1,6 +1,6 @@
 name = "Sekai Survival Modded"
 author = "Lutfilah Dzaky"
-version = "1.6.2"
+version = "1.6.3"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3ee631a9e054784c8b456c68be964708789a223a6992a5573abd542895d51a7d"
+hash = "f5d70e38aafd55c199d5a53d381ba511bb9a5366c6fa51500f5694e3b2b86190"
 
 [versions]
 fabric = "0.18.1"


### PR DESCRIPTION
Introduce configuration files for the Create mod to enhance train contraption light emission and adjust train speed settings. Disable MoreCulling compatibility for the Create Railways Navigator to fix connection issues between blocks. Update the pack version to 1.6.3.