### PR TITLE
Rename repository URL from sekai-packwiz to sekai-modpack

### DIFF
--- a/pack/client-files/unsup.ini
+++ b/pack/client-files/unsup.ini
@@ -2,7 +2,7 @@ version=1
 preset=minecraft
 
 source_format=packwiz
-source=https://lutfilahdz.github.io/sekai-packwiz/main/pack.toml
+source=https://lutfilahdz.github.io/sekai-modpack/main/pack.toml
 behavior=auto
 offer_change_flavors=true
 

--- a/pack/config/carryon-common.pw.toml
+++ b/pack/config/carryon-common.pw.toml
@@ -3,6 +3,6 @@ filename = "carryon-common.json"
 side = "server"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/server-files/config/carryon-common.json"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/carryon-common.json"
 hash-format = "sha512"
 hash = "0c47202ec2adabd3357b70348f1425311667df61994256931c9e847e69928f66ca3ac73b1c1a03ff13b62374b862440a7f8964018085c4278ea1be43156e85f2"

--- a/pack/config/craftpresence.pw.toml
+++ b/pack/config/craftpresence.pw.toml
@@ -3,6 +3,6 @@ filename = "craftpresence.json"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/config/craftpresence.json"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/config/craftpresence.json"
 hash-format = "sha512"
 hash = "c1a4a5f3a92a86716496901e9c5f475591438f86b786c5313b956a1af135bb10faf6be7aded2ed236ac6a0ba2e5da8593450182b2454dc53b2f66393754fb3c7"

--- a/pack/config/enhanced_bes.pw.toml
+++ b/pack/config/enhanced_bes.pw.toml
@@ -3,6 +3,6 @@ filename = "enhanced_bes.properties"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/config/enhanced_bes.properties"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/config/enhanced_bes.properties"
 hash-format = "sha512"
 hash = "d82141c11b6baeba3718d9628f8f85b8e7b23a82c5728f5a86040f119982f1a136fb41466cb27380b28da5c2549572d929e706ce747b8c0425384d12fb21c92f"

--- a/pack/config/genshinstrument-client.pw.toml
+++ b/pack/config/genshinstrument-client.pw.toml
@@ -3,6 +3,6 @@ filename = "genshinstrument-client.toml"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/config/genshinstrument-client.toml"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/config/genshinstrument-client.toml"
 hash-format = "sha512"
 hash = "d2ccc6111eda1de2e06fcf415bd6d6b9152b545ea4eb651ce63fe44e8a1be442689edddf30cd1fac24af6db0ab35a9081dd7cae8448a7da198968986e7f6bc76"

--- a/pack/config/kiwi-client.pw.toml
+++ b/pack/config/kiwi-client.pw.toml
@@ -3,6 +3,6 @@ filename = "kiwi-client.yaml"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/config/kiwi-client.yaml"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/config/kiwi-client.yaml"
 hash-format = "sha512"
 hash = "d6aa93830b62baae32760486f20d3355826c158bc4ebca8d8ce11781c75aacfb3aab47ebdc1b312d7f598d66f5872e94b9213fc0f5e4b0ea2addb9337a9d8ab7"

--- a/pack/config/moreculling.pw.toml
+++ b/pack/config/moreculling.pw.toml
@@ -3,6 +3,6 @@ filename = "moreculling.toml"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/config/moreculling.toml"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/config/moreculling.toml"
 hash-format = "sha512"
 hash = "58cf024a4931dd373df5fadfef3aff0bcbdcf070b37e8a67bd5f984f47713181c2b22b43ed3b826b520dff978fac8b7b138abbba5cb253daea6af4b2a4e65f18"

--- a/pack/config/universal-graves/models/default.pw.toml
+++ b/pack/config/universal-graves/models/default.pw.toml
@@ -3,6 +3,6 @@ filename = "default.json"
 side = "server"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/server-files/config/universal-graves/models/default.json"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/universal-graves/models/default.json"
 hash-format = "sha512"
 hash = "b206d3477ed587c8f379e8246e46fd0cbca48b10a5e9d40aca7f6c3a4f3f962cb4b2b1d21f376a2c7c172f5e87eff7e57b6aeb20d42f4f750b335befdb671c75"

--- a/pack/config/xaerominimap-common.pw.toml
+++ b/pack/config/xaerominimap-common.pw.toml
@@ -3,6 +3,6 @@ filename = "xaerominimap-common.txt"
 side = "server"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/server-files/config/xaerominimap-common.txt"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/xaerominimap-common.txt"
 hash-format = "sha512"
 hash = "6b1b2868db377051436bbc4371829b3e02a5ab0c1cf8990ccf82f704d31d296c7cc6768c435800b2f5442f1705d3fc3d35aced1aead52c6028666e851f718849"

--- a/pack/config/xaeroworldmap-common.pw.toml
+++ b/pack/config/xaeroworldmap-common.pw.toml
@@ -3,6 +3,6 @@ filename = "xaeroworldmap-common.txt"
 side = "server"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/server-files/config/xaeroworldmap-common.txt"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/xaeroworldmap-common.txt"
 hash-format = "sha512"
 hash = "8d8c62810c96afb4bfa29287fd1ef0285f3e18afd2f512d2a6c40678759a12dc07e7e42efb9118d2e624882712732396f5fe288ff12ac1486108225edd64ade2"

--- a/pack/config/yes_steve_model-common.pw.toml
+++ b/pack/config/yes_steve_model-common.pw.toml
@@ -3,6 +3,6 @@ filename = "yes_steve_model-common.toml"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/config/yes_steve_model-common.toml"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/config/yes_steve_model-common.toml"
 hash-format = "sha512"
 hash = "2abedb199dab8fb7eaf80b9274fff1778df9bcb72a85c2937f25600901ed1542cf9e3b235b6bd62ea5035aca0f75bc1404756500391ce4c8afe84fa2d7d53784"

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -2,12 +2,12 @@ hash-format = "sha256"
 
 [[files]]
 file = "config/carryon-common.pw.toml"
-hash = "11b8b237299d140e3cfc325565eea9fda010512a3bfaf319b99a567099f10b7d"
+hash = "2b8f82258a11643d20c058c9080d2fd0d199a2ad4bc4456afd2366f4cff011a3"
 metafile = true
 
 [[files]]
 file = "config/craftpresence.pw.toml"
-hash = "138c13e753b15feae87016905206d8807d106aa48416cae491f04a9cec1aac73"
+hash = "ee8ffe5e12c0129c23574ce85e7c9d1e5767484f91e83541b398a53b9800e682"
 metafile = true
 
 [[files]]
@@ -20,22 +20,22 @@ hash = "db035283717017bcfb594b0baac1139fc5792d3f51af5ba9b9dabc92b1573284"
 
 [[files]]
 file = "config/enhanced_bes.pw.toml"
-hash = "d31d883e8625aa09dfe0e8f6b665557cee1cc1edb54fbfdb07adcd19c694f0d2"
+hash = "507bcf61e5bca5eadbdd1ad21aa2a0055c7fcb02ef0c8c8d7ab56bf29558c354"
 metafile = true
 
 [[files]]
 file = "config/genshinstrument-client.pw.toml"
-hash = "5567d21d09fe15424d2fdfc3b46999f5735e6fbe8570c95168cab86fda0245d6"
+hash = "da147ec41c8c325bbf269347d00257c0e58439aef65d33ffe826ba148bfe5ca6"
 metafile = true
 
 [[files]]
 file = "config/kiwi-client.pw.toml"
-hash = "acff99d8a44be9a4131bad20ec8ab378aff56d52a7b922dbc9354dd77cedd390"
+hash = "e230ff5cbcceaa24a78cc96f1e4eb70adb9cfb31e7b7888c9282bcd57288b47a"
 metafile = true
 
 [[files]]
 file = "config/moreculling.pw.toml"
-hash = "8677ddfd288d1f9969a4885aeef0a701aee613fa2ec79bc448520c458ce131e8"
+hash = "5f2d61cb838f9913e41b7e8149c1759c685a7539ab6278a844014e7ef6e3cbf2"
 metafile = true
 
 [[files]]
@@ -44,22 +44,22 @@ hash = "c2d27c9f937eb4e7dd8a0f13213ac8d52c4f3e1aeae4c1095703e1fdecdcd0e6"
 
 [[files]]
 file = "config/universal-graves/models/default.pw.toml"
-hash = "fe73f0b8b93b38be3932ef50df06aa18a0e3fa09b6167b22b220218e4bcd0eae"
+hash = "d70bee5636b4cfed584ecc78df9eea68d5c3c0ed358cc48b7c753a8b38845094"
 metafile = true
 
 [[files]]
 file = "config/xaerominimap-common.pw.toml"
-hash = "25ea9b686beac5057cf9d34ed7768908e7d32b21a4981241d261770062ea4e4e"
+hash = "89464085d620144e65e2077218ee5713e3505014e3de24aec635e77111ee0bb3"
 metafile = true
 
 [[files]]
 file = "config/xaeroworldmap-common.pw.toml"
-hash = "097753ccf0dc8c348607098c0fd5c24544c2b4720b24649fbf6d08a8de0136a3"
+hash = "78b63c096f3014455f5641a13c1d5311aa9125fccea4f1cf337ecdcbe627736b"
 metafile = true
 
 [[files]]
 file = "config/yes_steve_model-common.pw.toml"
-hash = "9caca2d55ddb0a668660694448b04b882257c0bdac133f86d934eef89cc000dc"
+hash = "85067b8317b4ee266547f37d4609de917289ecfcc611da8601dbc5561874817c"
 metafile = true
 
 [[files]]
@@ -1264,22 +1264,22 @@ metafile = true
 
 [[files]]
 file = "options.pw.toml"
-hash = "96c716b287bf46f83557680f935c25d246f872426b879c6f7b45d94755dad911"
+hash = "90e183ff4e0166252dc385f8cce8ad1e9e3203996551bdab9a7e62562c371361"
 metafile = true
 
 [[files]]
 file = "servers-dat.pw.toml"
-hash = "9ff1b96987c641c5fd1d94797b5b9443fa03f9a70c76cd4623ab3f48adef91d4"
+hash = "c1321bb52eebaa28a1477435f0c70760f503f0d0901c54963508bd5950c78126"
 metafile = true
 
 [[files]]
 file = "unsup-client.pw.toml"
-hash = "fa9a65a1d8a6ac8243c3e76eb4244dede09f661cc39598bc63a7c384ace8f163"
+hash = "131230907bc7fbeb9ccafc2a7448b43db34d7ee1883988dcab1259ba8dac5027"
 metafile = true
 
 [[files]]
 file = "unsup-server.pw.toml"
-hash = "77469a2b403b443022fe136accaf5f3ec2c1531ad168fffe9d49c10078c4192c"
+hash = "58471eb1a2ae437481d17728d3e6ccf40886c1d378ae3e2154ed136eff993618"
 metafile = true
 
 [[files]]

--- a/pack/options.pw.toml
+++ b/pack/options.pw.toml
@@ -3,6 +3,6 @@ filename = "options.txt"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/options.txt"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/options.txt"
 hash-format = "sha512"
 hash = "ba3f92b1194c401293d548653bbf19f7764df961b58250619f1a34808b5a2d0a043a9c526556ca36fafc75118ba6e249a2684e1cfa6d32db459b51a7d2d4f2c1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "11e9fc026b38474cc450e42c5ea58db59bdcd6aa76944118155e51e876b3406f"
+hash = "2229934aab89d2b932235e0c487ea4713bc8e3b94164012b3e5f22bba2f1734c"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/server-files/unsup.ini
+++ b/pack/server-files/unsup.ini
@@ -2,7 +2,7 @@ version=1
 preset=minecraft
 
 source_format=packwiz
-source=https://lutfilahdz.github.io/sekai-packwiz/main/pack.toml
+source=https://lutfilahdz.github.io/sekai-modpack/main/pack.toml
 behavior=auto
 offer_change_flavors=true
 

--- a/pack/servers-dat.pw.toml
+++ b/pack/servers-dat.pw.toml
@@ -3,6 +3,6 @@ filename = "servers.dat"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/servers.dat"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/servers.dat"
 hash-format = "sha512"
 hash = "62116dfb185691b90e7d6f565d2d18c5ba55d31221f8b4782663fbfeb72a207fad07c50609921fd83ae1e886fd9528d4e63bc84ec90fc2d42e96038a625a0664"

--- a/pack/unsup-client.pw.toml
+++ b/pack/unsup-client.pw.toml
@@ -3,6 +3,6 @@ filename = "unsup.ini"
 side = "client"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/client-files/unsup.ini"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/client-files/unsup.ini"
 hash-format = "sha512"
 hash = "50fee1620ca8d8aa51ccd009e25afdd3443d58304c5df76aa3eeff0889a3b5b490bf265a10ad6098602438411dbcad0e7bda79b5ed0db04737b12d13fecd0a25"

--- a/pack/unsup-server.pw.toml
+++ b/pack/unsup-server.pw.toml
@@ -3,6 +3,6 @@ filename = "unsup.ini"
 side = "server"
 
 [download]
-url = "https://lutfilahdz.github.io/sekai-packwiz/main/server-files/unsup.ini"
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/unsup.ini"
 hash-format = "sha512"
 hash = "31e548f7c1efbe6c8c9f28311abd557ce65ed4ec41b6eece6d9ea200bba26d3c267005b6462172a3861935f0f3d4a31df10c205f32bd087a8a9e84385a84e8c0"


### PR DESCRIPTION
Update all download URLs and source references across configuration files to use the new repository name