### PR TITLE
v1.6.7: Add new mods, configs, and server-side settings

### DIFF
--- a/pack/config/antientitygrief.toml
+++ b/pack/config/antientitygrief.toml
@@ -1,0 +1,8 @@
+name = "config/antientitygrief.json (server)"
+filename = "antientitygrief.json"
+side = "server"
+
+[download]
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/antientitygrief.json"
+hash-format = "sha512"
+hash = "57c1c028c5f79ad890bf38c6262268026dc536074bc3d860eee4684c6d0f150afa474d61236fa001d6935af62f084f8c9dc69efb28bab676e81b1dea02bf3acf"

--- a/pack/config/carryon-common.json
+++ b/pack/config/carryon-common.json
@@ -177,7 +177,13 @@
       "powah:*",
       "advancementtrophies:trophy",
       "mekanismgenerators:heat_generator",
-      "mna:filler_block"
+      "mna:filler_block",
+      "escalated:*",
+      "design_decor:stepped_lever",
+      "copycats:copycat_iron_door",
+      "copycats:copycat_folding_door",
+      "copycats:copycat_sliding_door",
+      "copycats:copycat_door"
     ],
     "//forbiddenEntities": "Entities that cannot be picked up",
     "forbiddenEntities": [

--- a/pack/config/carryon-common.json
+++ b/pack/config/carryon-common.json
@@ -180,10 +180,11 @@
       "mna:filler_block",
       "escalated:*",
       "design_decor:stepped_lever",
+      "copycats:copycat_door",
       "copycats:copycat_iron_door",
-      "copycats:copycat_folding_door",
       "copycats:copycat_sliding_door",
-      "copycats:copycat_door"
+      "copycats:copycat_folding_door",
+      "trainutilities:door_*"
     ],
     "//forbiddenEntities": "Entities that cannot be picked up",
     "forbiddenEntities": [

--- a/pack/config/carryon-common.pw.toml
+++ b/pack/config/carryon-common.pw.toml
@@ -1,8 +1,0 @@
-name = "config/carryon-common.json (server)"
-filename = "carryon-common.json"
-side = "server"
-
-[download]
-url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/carryon-common.json"
-hash-format = "sha512"
-hash = "0c47202ec2adabd3357b70348f1425311667df61994256931c9e847e69928f66ca3ac73b1c1a03ff13b62374b862440a7f8964018085c4278ea1be43156e85f2"

--- a/pack/config/creeperoverhaul.toml
+++ b/pack/config/creeperoverhaul.toml
@@ -1,0 +1,8 @@
+name = "config/creeperoverhaul.jsonc (server)"
+filename = "creeperoverhaul.jsonc"
+side = "server"
+
+[download]
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/creeperoverhaul.jsonc"
+hash-format = "sha512"
+hash = "eb062289bbee194e297dc5f39e43702041fa083e24b5ec589714066c39466534d91f9471fcab1f72fddc70a02969ccb221fac0f7647e88018c3d93e0b190816f"

--- a/pack/config/endermanoverhaul.toml
+++ b/pack/config/endermanoverhaul.toml
@@ -1,0 +1,8 @@
+name = "config/endermanoverhaul.jsonc (server)"
+filename = "endermanoverhaul.jsonc"
+side = "server"
+
+[download]
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/endermanoverhaul.jsonc"
+hash-format = "sha512"
+hash = "f2e44d16349f6b28ad3a785e317b2323aec64daa6e066d44d2e0da2f7756eddf3058503b08436324c22738b05c16aa5cc93625e33b2ac3e4785104ff059df818"

--- a/pack/config/fabric_loader_dependencies.json
+++ b/pack/config/fabric_loader_dependencies.json
@@ -1,0 +1,10 @@
+{
+    "version": 1,
+    "overrides": {
+        "design_decor": {
+            "-depends": {
+                "create": ""
+            }
+        }
+    }
+}

--- a/pack/config/paxi/resourcepacks/colorful-nixies.pw.toml
+++ b/pack/config/paxi/resourcepacks/colorful-nixies.pw.toml
@@ -1,0 +1,13 @@
+name = "Colorful Nixies"
+filename = "ColorfulNixies.zip"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/Gy8bflzI/versions/KMHgM1cs/ColorfulNixies.zip"
+hash-format = "sha512"
+hash = "98515f3c9e8f2174ae15784020de062fb0a4a04d42e0995cefe9ca14a08845b38ccac0d69a4cfb188f7a298d3d05413f00a59eb7c85627882d141329e0c0a821"
+
+[update]
+[update.modrinth]
+mod-id = "Gy8bflzI"
+version = "KMHgM1cs"

--- a/pack/config/paxi/resourcepacks/enhanced-boss-bars.pw.toml
+++ b/pack/config/paxi/resourcepacks/enhanced-boss-bars.pw.toml
@@ -1,0 +1,13 @@
+name = "Enhanced Boss Bars"
+filename = "[1.4.1] Enhanced Boss Bars.zip"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/U5SedJ9S/versions/3fjpw8Kj/%5B1.4.1%5D%20Enhanced%20Boss%20Bars.zip"
+hash-format = "sha512"
+hash = "e2ab6353357cd06e7d92670baeff994f3d3e87bb6bbb8243b8f74b4a2012118ace418772118510bfc9228b94ca44586f14f01d6eb33f885a6ca45608033782a9"
+
+[update]
+[update.modrinth]
+mod-id = "U5SedJ9S"
+version = "3fjpw8Kj"

--- a/pack/config/xaero/lib/common.pw.toml
+++ b/pack/config/xaero/lib/common.pw.toml
@@ -1,0 +1,8 @@
+name = "config/xaero/lib/common.cfg (server)"
+filename = "common.cfg"
+side = "server"
+
+[download]
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/xaero/lib/common.cfg"
+hash-format = "sha512"
+hash = "be769b92821bc9b071516b5784f1880c4c55de5aec090d59ceb993b7e11f0c43c44df14d37d7fc709e2e4b6aaf215b7e3e91ec9bba667a2d77a731c8df47f96a"

--- a/pack/config/xaero/minimap/server_profiles/default.pw.toml
+++ b/pack/config/xaero/minimap/server_profiles/default.pw.toml
@@ -1,0 +1,8 @@
+name = "config/xaero/minimap/server_profiles/default.cfg (server)"
+filename = "default.cfg"
+side = "server"
+
+[download]
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/xaero/minimap/server_profiles/default.cfg"
+hash-format = "sha512"
+hash = "c397fc11a31093b09168b8f79d69d63849c7e53de486754eb7f9a5153c3a5154bc3f66ad512511a38eafcbe9892350f14b68f52ba8989bf12913ab898cde9e63"

--- a/pack/config/xaero/world-map/server_profiles/default.pw.toml
+++ b/pack/config/xaero/world-map/server_profiles/default.pw.toml
@@ -1,0 +1,8 @@
+name = "config/xaero/world-map/server_profiles/default.cfg (server)"
+filename = "default.cfg"
+side = "server"
+
+[download]
+url = "https://lutfilahdz.github.io/sekai-modpack/main/server-files/config/xaero/world-map/server_profiles/default.cfg"
+hash-format = "sha512"
+hash = "e4963a2a2bfdd18553bed877ede931b19a39ed7b31040d3b8a22764d82774fa018fa275651e9ab07af01df1485e805edca96697d20d44b528f89abe754b03973"

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -358,6 +358,11 @@ hash = "f9784ac1511b83e0e3bf7df5b2240170d41e01b285b2b4455ef702113451aa6a"
 metafile = true
 
 [[files]]
+file = "mods/create-tramways-hotfix.pw.toml"
+hash = "e3c965d0d9c20da9ebcd81f806c8c41a619dc13278c8eb314af07a588e7842c0"
+metafile = true
+
+[[files]]
 file = "mods/creativecore.pw.toml"
 hash = "af83eb1ea0f7a36e4424248c744c1cbebb5045d361e843b873d4d89bf65ad8ad"
 metafile = true

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -2,7 +2,7 @@ hash-format = "sha256"
 
 [[files]]
 file = "config/carryon-common.json"
-hash = "12256060b807c36167c5ce79d125cde9600b64fe57bce40cc012ca9f8b5508dd"
+hash = "5637a6a61a4f968d4f3a8161d01a7ee7e72c4d30280486a3d8bda749a99a4a56"
 
 [[files]]
 file = "config/craftpresence.pw.toml"

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -1,9 +1,8 @@
 hash-format = "sha256"
 
 [[files]]
-file = "config/carryon-common.pw.toml"
-hash = "2b8f82258a11643d20c058c9080d2fd0d199a2ad4bc4456afd2366f4cff011a3"
-metafile = true
+file = "config/carryon-common.json"
+hash = "12256060b807c36167c5ce79d125cde9600b64fe57bce40cc012ca9f8b5508dd"
 
 [[files]]
 file = "config/craftpresence.pw.toml"

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -73,13 +73,28 @@ hash = "d70bee5636b4cfed584ecc78df9eea68d5c3c0ed358cc48b7c753a8b38845094"
 metafile = true
 
 [[files]]
+file = "config/xaero/lib/common.pw.toml"
+hash = "415dc6f93f83dd66b1dc0375a5a85aa051eaeddd7097d49ff4b870a5fe88b520"
+metafile = true
+
+[[files]]
 file = "config/xaero/minimap/client.pw.toml"
 hash = "50b4fc1345378c0c553b391c64d470ba404f792f68b9e2aebb61192d7448b9f7"
 metafile = true
 
 [[files]]
+file = "config/xaero/minimap/server_profiles/default.pw.toml"
+hash = "dfd74e7b75d09064596d0f49c70fedecf0153891fd13154bebeb46c2da9fc35c"
+metafile = true
+
+[[files]]
 file = "config/xaero/world-map/client.pw.toml"
 hash = "67a2bcc3569c836811c6742b5d0895d8c8b328393371d60639cff377fd88ff39"
+metafile = true
+
+[[files]]
+file = "config/xaero/world-map/server_profiles/default.pw.toml"
+hash = "b9251428bc505ed1e89fe6fe264ca062b5b118d820ae4b6d19311ee3e7b535c7"
 metafile = true
 
 [[files]]

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -96,6 +96,11 @@ hash = "a2514b93ee462130af7905208c993847eda9eb7ddb4a244a34e912b445ae9b54"
 metafile = true
 
 [[files]]
+file = "mods/aileron.pw.toml"
+hash = "c631326a0c1333d1664315857d460cb3e1d5f3a54a75b8e6ac65944e93d2e455"
+metafile = true
+
+[[files]]
 file = "mods/almanac.pw.toml"
 hash = "6317bd1e6013059a52574d7002e744cd1d662ba345d019d75e37d384fd6060b0"
 metafile = true
@@ -328,6 +333,11 @@ metafile = true
 [[files]]
 file = "mods/create-threaded-trains.pw.toml"
 hash = "a171827ca41197cfe596f6624bdf574cbbc6532642c1f4dfd5a9d84de908e4b1"
+metafile = true
+
+[[files]]
+file = "mods/create-toolbox-tooltip.pw.toml"
+hash = "33fba1af5c52c0d2331777cb3405f9c53b2800f6b92427471df8820c442bbc24"
 metafile = true
 
 [[files]]

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -39,6 +39,16 @@ hash = "5f2d61cb838f9913e41b7e8149c1759c685a7539ab6278a844014e7ef6e3cbf2"
 metafile = true
 
 [[files]]
+file = "config/paxi/resourcepacks/colorful-nixies.pw.toml"
+hash = "28b4bafa3f7ce93e293ce15d0f23515b3e0b4f3046d2639847ac6ab17113e90d"
+metafile = true
+
+[[files]]
+file = "config/paxi/resourcepacks/enhanced-boss-bars.pw.toml"
+hash = "88496e670b35be0585d76f593cad1e59e76e7e9c4a014d5e8e4ce8c8b8e29986"
+metafile = true
+
+[[files]]
 file = "config/tide.toml"
 hash = "c2d27c9f937eb4e7dd8a0f13213ac8d52c4f3e1aeae4c1095703e1fdecdcd0e6"
 
@@ -905,6 +915,11 @@ metafile = true
 [[files]]
 file = "mods/passable-foliage.pw.toml"
 hash = "d2f38114e14bd2d44c9a25bea37791ad899345cfe73828858c0ac61ffe28f2e3"
+metafile = true
+
+[[files]]
+file = "mods/paxi.pw.toml"
+hash = "58e0dcbd933909735c31a0da3009fc05276b322196026137ef39da9a50525d8d"
 metafile = true
 
 [[files]]

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -1,6 +1,10 @@
 hash-format = "sha256"
 
 [[files]]
+file = "config/antientitygrief.toml"
+hash = "3deae454603042cca46b213e6e3c7d47f443b0c06516f16d292e50c3e1c0e342"
+
+[[files]]
 file = "config/carryon-common.json"
 hash = "5637a6a61a4f968d4f3a8161d01a7ee7e72c4d30280486a3d8bda749a99a4a56"
 
@@ -16,6 +20,14 @@ hash = "4877aee40f7e40299b9756f638482fd30d3c0ef632bfbf443f8805157b5d5bf7"
 [[files]]
 file = "config/create-server.toml"
 hash = "db035283717017bcfb594b0baac1139fc5792d3f51af5ba9b9dabc92b1573284"
+
+[[files]]
+file = "config/creeperoverhaul.toml"
+hash = "6409dbfc8556467a2970b90e93fd92cece655cd9c221dbd7a293fac3dbf71e0f"
+
+[[files]]
+file = "config/endermanoverhaul.toml"
+hash = "c6ff54b318c6a83b19a514b3bd22ee65628cb240e6dff9e08870e2d596b38a08"
 
 [[files]]
 file = "config/enhanced_bes.pw.toml"

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -24,6 +24,10 @@ hash = "507bcf61e5bca5eadbdd1ad21aa2a0055c7fcb02ef0c8c8d7ab56bf29558c354"
 metafile = true
 
 [[files]]
+file = "config/fabric_loader_dependencies.json"
+hash = "b0b9371f3f5f19a5ad5a839db4e4ce8b1922a4833bfbb709e7bfe2e366a4f34a"
+
+[[files]]
 file = "config/genshinstrument-client.pw.toml"
 hash = "da147ec41c8c325bbf269347d00257c0e58439aef65d33ffe826ba148bfe5ca6"
 metafile = true
@@ -265,6 +269,11 @@ metafile = true
 [[files]]
 file = "mods/create-deco.pw.toml"
 hash = "023532063fbf310dd047a33cf1afd06b0c4baf72da4dc23e78d1d599ad5dcccd"
+metafile = true
+
+[[files]]
+file = "mods/create-design-n-decor.pw.toml"
+hash = "80c5ee4c23d552b939a151d7f694c3d046792dc45ff6dd0dbfbc88d1a2ba77a7"
 metafile = true
 
 [[files]]

--- a/pack/mods/aileron.pw.toml
+++ b/pack/mods/aileron.pw.toml
@@ -1,0 +1,13 @@
+name = "Aileron"
+filename = "aileron-1.20.1-fabric-1.1.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/b8kG1VGq/versions/CKTzM3yu/aileron-1.20.1-fabric-1.1.1.jar"
+hash-format = "sha512"
+hash = "354d74dff8d99ebe63b6a53f613c2db837055291dc96e2ce3ecd39522be3c2eead606b7e192be654dccc34018d899b1e3904a5d540e5f289dbabd99b1e34dd5b"
+
+[update]
+[update.modrinth]
+mod-id = "b8kG1VGq"
+version = "CKTzM3yu"

--- a/pack/mods/create-design-n-decor.pw.toml
+++ b/pack/mods/create-design-n-decor.pw.toml
@@ -1,0 +1,13 @@
+name = "Create: Design n' Decor"
+filename = "design_decor-0.4.0b_fabric+1.20.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/x49wilh8/versions/6bv4ASFG/design_decor-0.4.0b_fabric%2B1.20.1.jar"
+hash-format = "sha512"
+hash = "1df837efcdb8b5e7cc6bf1de2af93e351958f8ecdbe690b70ed73fea9082c69d0ecd5c1c45a2eae595309a7b20458b9f26d125f70dd06335f8ded2cee8ef7b9f"
+
+[update]
+[update.modrinth]
+mod-id = "x49wilh8"
+version = "6bv4ASFG"

--- a/pack/mods/create-toolbox-tooltip.pw.toml
+++ b/pack/mods/create-toolbox-tooltip.pw.toml
@@ -1,0 +1,13 @@
+name = "Create Toolbox Tooltip"
+filename = "createtoolboxtooltip-1.0.1+1.20.1-fabric.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/Dzv48h3w/versions/SszOZ8Nw/createtoolboxtooltip-1.0.1%2B1.20.1-fabric.jar"
+hash-format = "sha512"
+hash = "f26ff132fcd40362147860b025fb934857bd2aa7a1b4e1220ea1bdcee4e154f8dfdef9fd7411611dd99bf7829a343378e096834bec465010e40d009033a6f6b8"
+
+[update]
+[update.modrinth]
+mod-id = "Dzv48h3w"
+version = "SszOZ8Nw"

--- a/pack/mods/create-tramways-hotfix.pw.toml
+++ b/pack/mods/create-tramways-hotfix.pw.toml
@@ -1,0 +1,13 @@
+name = "Create: Tramways Hotfix"
+filename = "tramways_hotfix-fabric-0.0.1.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "e9d84d9b7beb6c2fbc5a59492a6a79c14a397ed6"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6972105
+project-id = 1342700

--- a/pack/mods/paxi.pw.toml
+++ b/pack/mods/paxi.pw.toml
@@ -1,0 +1,13 @@
+name = "Paxi"
+filename = "Paxi-1.20-Fabric-4.0.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/CU0PAyzb/versions/UVPLKCqf/Paxi-1.20-Fabric-4.0.jar"
+hash-format = "sha512"
+hash = "81a9918d6730db5d9b1b1eae3a7104ba4d83557aa90308b9acc1026cae1789265b7ebde9c6a573ebaca91bae6e0988f069f442f4d18d63f1c46909a758080e9e"
+
+[update]
+[update.modrinth]
+mod-id = "CU0PAyzb"
+version = "UVPLKCqf"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "28e06948775852644e027f45b68048cf3e39bc6e7b941d6553029a4a00606952"
+hash = "571eae7a7bb2cc36a32d51bff26c6bd56e53c4c44371dde31dc834d3be8157f4"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3fc624334e0241b7f1b867f6c9ac5e7d640f0ad65aed84cac31d9e25ef4a581d"
+hash = "3fa70467c75873cb940ea62f47978b16b3b03490dec04bf4ef4b0a810b2b139c"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3fa70467c75873cb940ea62f47978b16b3b03490dec04bf4ef4b0a810b2b139c"
+hash = "28e06948775852644e027f45b68048cf3e39bc6e7b941d6553029a4a00606952"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "cf928ee3837d112094a9058eac6d51576227551728f4f515f7a305880ca941ee"
+hash = "b00fe20a92b965ecd48d51ca8bf2571443191ed9ee791eb265fd765b8342e126"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -1,6 +1,6 @@
 name = "Sekai Survival Modded"
 author = "Lutfilah Dzaky"
-version = "1.6.6"
+version = "1.6.7"
 pack-format = "packwiz:1.1.0"
 
 [index]

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "97b2b95f554965602a091ecb1d41fce4cf41f90cc65cb61f06ad96cd56d116ae"
+hash = "44c0a2af330b90a2919c0d95b459f5223fc4110a48bf5653908280b46bc32967"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "b00fe20a92b965ecd48d51ca8bf2571443191ed9ee791eb265fd765b8342e126"
+hash = "3fc624334e0241b7f1b867f6c9ac5e7d640f0ad65aed84cac31d9e25ef4a581d"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "571eae7a7bb2cc36a32d51bff26c6bd56e53c4c44371dde31dc834d3be8157f4"
+hash = "97b2b95f554965602a091ecb1d41fce4cf41f90cc65cb61f06ad96cd56d116ae"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "44c0a2af330b90a2919c0d95b459f5223fc4110a48bf5653908280b46bc32967"
+hash = "46ba1df37257a9a49c267d4b261edb7717945cb262bf01f706d9dd63065e1e0a"
 
 [versions]
 fabric = "0.18.1"

--- a/pack/server-files/config/antientitygrief.json
+++ b/pack/server-files/config/antientitygrief.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "entities": {
+    "minecraft:creeper": {
+      "EXPLODE_BLOCKS": false
+    },
+    "minecraft:drowned": {
+      "BREAK_DOORS": false
+    },
+    "minecraft:end_crystal": {
+      "EXPLODE_BLOCKS": false
+    },
+    "minecraft:ender_dragon": {
+      "DESTROY_BLOCKS": false
+    },
+    "minecraft:enderman": {
+      "DESTROY_BLOCKS": false,
+      "PLACE_BLOCKS": false
+    },
+    "minecraft:ghast": {
+      "EXPLODE_BLOCKS": false
+    },
+    "minecraft:husk": {
+      "BREAK_DOORS": false
+    },
+    "minecraft:ravager": {
+      "DESTROY_BLOCKS": false
+    },
+    "minecraft:silverfish": {
+      "DESTROY_BLOCKS": false
+    },
+    "minecraft:tnt": {
+      "EXPLODE_BLOCKS": false
+    },
+    "minecraft:tnt_minecart": {
+      "EXPLODE_BLOCKS": false
+    },
+    "minecraft:wither": {
+      "DESTROY_BLOCKS": false,
+      "EXPLODE_BLOCKS": false
+    },
+    "minecraft:zombie": {
+      "BREAK_DOORS": false
+    },
+    "minecraft:zombie_villager": {
+      "BREAK_DOORS": false
+    },
+    "minecraft:zombified_piglin": {
+      "BREAK_DOORS": false
+    }
+  }
+}

--- a/pack/server-files/config/creeperoverhaul.jsonc
+++ b/pack/server-files/config/creeperoverhaul.jsonc
@@ -1,0 +1,3 @@
+{
+    "destroyBlocks": false
+}

--- a/pack/server-files/config/endermanoverhaul.jsonc
+++ b/pack/server-files/config/endermanoverhaul.jsonc
@@ -1,0 +1,3 @@
+{
+    "allowPickingUpBlocks": false
+}

--- a/pack/server-files/config/xaero/lib/common.cfg
+++ b/pack/server-files/config/xaero/lib/common.cfg
@@ -1,0 +1,1 @@
+everyone_tracks_everyone = true

--- a/pack/server-files/config/xaero/minimap/server_profiles/default.cfg
+++ b/pack/server-files/config/xaero/minimap/server_profiles/default.cfg
@@ -1,0 +1,8 @@
+############
+## Server Config Profile "default"
+##
+
+profile_name = Default
+display_radar = false
+minimap_cave_mode_allowed = false
+minimap_cave_mode_allowed_dimensions = [minecraft:the_nether]

--- a/pack/server-files/config/xaero/world-map/server_profiles/default.cfg
+++ b/pack/server-files/config/xaero/world-map/server_profiles/default.cfg
@@ -1,0 +1,8 @@
+############
+## Server Config Profile "default"
+##
+
+profile_name = Default
+display_minimap_radar = false
+cave_mode_allowed = false
+cave_mode_allowed_dimensions = [minecraft:the_nether]


### PR DESCRIPTION
## Summary
This PR adds new mods, resource packs, and server-side configurations to improve gameplay experience.

## New Mods
- **Paxi** - Resource pack management with Colorful Nixies and Enhanced Boss Bars
- **Create: Design n' Decor** - Additional decorative blocks for Create
- **Aileron** - Enhanced elytra mechanics
- **Create Toolbox Tooltip** - Shows toolbox contents on hover
- **Create: Tramways Hotfix** - Fix client freeze when using speakers on trains (Ref: PurpleCreate/Tramways#18)

## Configuration Changes
- **Carry On blacklist updates:**
  - Escalated mod blocks
  - Design n' Decor stepped lever
  - Copycats doors (sliding/folding)
  - Train Utilities doors

- **Anti Entity Grief configs:**
  - Disable explosion block damage (Creeper, Ghast, Wither, TNT)
  - Disable Enderman block pickup/place
  - Disable zombie door breaking
  - Creeper Overhaul: `destroyBlocks = false`
  - Enderman Overhaul: `allowPickingUpBlocks = false`

- **Xaero's Maps server profiles:**
  - Disable entity radar display
  - Disable cave mode (allowed only in the Nether)
  - Enable `everyone_tracks_everyone` for shared player tracking