### PR TITLE
Hotfix: pin & update PandaLib, Panda's Falling Trees

### DIFF
--- a/pack/index.toml
+++ b/pack/index.toml
@@ -1018,12 +1018,12 @@ metafile = true
 
 [[files]]
 file = "mods/pandalib.pw.toml"
-hash = "c2c62c307dba17fc9f4072f93ee0f87fd32ddf7fbd8daa9593f8480e33136dfb"
+hash = "ff7cba9f585ee04471d6c3fefc2a2117c372bb5c94c8001c6d24c99bd4fb0c9a"
 metafile = true
 
 [[files]]
 file = "mods/pandas-falling-trees.pw.toml"
-hash = "64d2ced36641b4c329f4a2048df572d356bfae2cc368d4bfed77d0a8ae7461a2"
+hash = "ae10e438adf5bf2cbe4cfc183ab247a61f2bf1483028c840d388d9152fc5e49d"
 metafile = true
 
 [[files]]

--- a/pack/mods/pandalib.pw.toml
+++ b/pack/mods/pandalib.pw.toml
@@ -1,13 +1,14 @@
 name = "PandaLib"
-filename = "pandalib-fabric-1.20.1-1.0.0-ALPHA.2.2.jar"
+filename = "pandalib-fabric-mc1.20-0.5.2-SNAPSHOT.jar"
 side = "both"
+pin = true
 
 [download]
-url = "https://cdn.modrinth.com/data/mEEGbEIu/versions/DSiAPvLT/pandalib-fabric-1.20.1-1.0.0-ALPHA.2.2.jar"
+url = "https://cdn.modrinth.com/data/mEEGbEIu/versions/pdcdnDQm/pandalib-fabric-mc1.20-0.5.2-SNAPSHOT.jar"
 hash-format = "sha512"
-hash = "e89ce094ebba0e5aa0d64b8e94ce65f306378d22ae23a591f4e151bc43f4e0f2b2fa20ba36480c8567e1ea7f4aded5ea3c840f880caff0e930f3e4daac6567ec"
+hash = "8ec6d24fbd5d816f913cfe00271b2d7c277f66e0ea6b48fb92092ba4cfc0745f85bb72b25f6366772049f65c1e9455f581dfd163619c869d84d111c6a472f5b1"
 
 [update]
 [update.modrinth]
 mod-id = "mEEGbEIu"
-version = "DSiAPvLT"
+version = "pdcdnDQm"

--- a/pack/mods/pandas-falling-trees.pw.toml
+++ b/pack/mods/pandas-falling-trees.pw.toml
@@ -1,13 +1,14 @@
-name = "Panda's Falling Tree's"
-filename = "fallingtrees-fabric-1.20.1-0.14.0-APLHA.2.2.jar"
+name = "Panda's Falling Trees"
+filename = "fallingtrees-fabric-mc1.20-0.13.2-SNAPSHOT.jar"
 side = "both"
+pin = true
 
 [download]
-url = "https://cdn.modrinth.com/data/i2kUe4lq/versions/gpVoD5Rw/fallingtrees-fabric-1.20.1-0.14.0-APLHA.2.2.jar"
+url = "https://cdn.modrinth.com/data/i2kUe4lq/versions/N00bYlSS/fallingtrees-fabric-mc1.20-0.13.2-SNAPSHOT.jar"
 hash-format = "sha512"
-hash = "88a17979f4171c29299daec33d972e889ccf4090bd17ec383a892c29d83dd5e896c2eff52835e8742ac8c10202a1e40389ccaed32bfcf0a8a74983732f020256"
+hash = "006a2c17b1882fcf3f273df8e597aeac4c1c3906540a32fe9a99282253620e2765801cf01fa0c6b2d5a6ebe8ad767e6e6f73e882a32cdf94992ce4e0d31fc768"
 
 [update]
 [update.modrinth]
 mod-id = "i2kUe4lq"
-version = "gpVoD5Rw"
+version = "N00bYlSS"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -1,12 +1,12 @@
 name = "Sekai Survival Modded"
 author = "Lutfilah Dzaky"
-version = "1.8.1"
+version = "1.8.2"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "4a1024109d396d3948d7cd5a64fcc70339b7539b6be9daccb7b2443d1d6deb38"
+hash = "4788a4689c370c6000cbf3b193ba9b811d35ce297ed7b75892ad069bfc2db2ad"
 
 [versions]
 fabric = "0.18.4"


### PR DESCRIPTION
Updated PandaLib to 0.5.2-SNAPSHOT and Panda's Falling Trees to 0.13.2-SNAPSHOT to resolve crash issues. Enabled pinning for both mods to prevent version drift and ensure stability. Updated download URLs, hashes, and modrinth version references. Refreshed index hash in pack.toml.