### PR TITLE
1.10.0 hotfix

### DIFF
--- a/pack/index.toml
+++ b/pack/index.toml
@@ -1230,7 +1230,7 @@ metafile = true
 
 [[files]]
 file = "mods/skinrestorer.pw.toml"
-hash = "26096d8f51d60a126b6b0fefa07a49d56e17b65107306b763822f9ebdaa8a33e"
+hash = "0d8a3108fe5bca3af46bc1eb50eab01800da95e11200ab06fb9e23ac12b19742"
 metafile = true
 
 [[files]]

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -1064,6 +1064,11 @@ hash = "2149e8ba3fc2c56905e6bbc06efd4ece5999d8babea605386ec5bd1af26aef90"
 metafile = true
 
 [[files]]
+file = "mods/necronomicon.pw.toml"
+hash = "0a51aa853f7ec0323cabc98e9c6957e35f8e8581f1ee5ce12eb95d0e98665fc2"
+metafile = true
+
+[[files]]
 file = "mods/nethers-delight-refabricated.pw.toml"
 hash = "80b0b7333c6c4235d840800afc8583a1e03f5fe493dd8085bf46dbf18e48eab3"
 metafile = true

--- a/pack/mods/necronomicon.pw.toml
+++ b/pack/mods/necronomicon.pw.toml
@@ -1,0 +1,13 @@
+name = "Necronomicon API"
+filename = "Necronomicon-Fabric-1.6.0+1.20.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/P1Kv5EAO/versions/bgc6xYvl/Necronomicon-Fabric-1.6.0%2B1.20.1.jar"
+hash-format = "sha512"
+hash = "c412d5e028085b6b21c611b3d2c60bbc9f4aae442bb448e80a40a44568d715415d5713f1bdc7e023937e7f7d50e855b47dd31e4fed4cfb856f709c0c0996e782"
+
+[update]
+[update.modrinth]
+mod-id = "P1Kv5EAO"
+version = "bgc6xYvl"

--- a/pack/mods/skinrestorer.pw.toml
+++ b/pack/mods/skinrestorer.pw.toml
@@ -1,13 +1,13 @@
 name = "Skin Restorer"
-filename = "skinrestorer-2.5.0+1.20-fabric.jar"
+filename = "skinrestorer-2.6.0+1.20-fabric.jar"
 side = "server"
 
 [download]
-url = "https://cdn.modrinth.com/data/ghrZDhGW/versions/b8GoBEZd/skinrestorer-2.5.0%2B1.20-fabric.jar"
+url = "https://cdn.modrinth.com/data/ghrZDhGW/versions/FsXZTDtg/skinrestorer-2.6.0%2B1.20-fabric.jar"
 hash-format = "sha512"
-hash = "cf8bac44fa7fe0954efc9cb9675dd49e8147fbbb3a3c28c9dbe5b3d8a197978f0a6fc0cdb82af45e65e32d3daa99ee6446a9ec7e61aa2f054b499b373bec1c19"
+hash = "e41c51a0bbe856da3abeac6b0e37c4983d6033327faa71babbd9e7ce38bf869be1ee04a03a32eeb59dd73db53bbfd531724371d12281b45a4f5ee0bafd5fc6c4"
 
 [update]
 [update.modrinth]
 mod-id = "ghrZDhGW"
-version = "b8GoBEZd"
+version = "FsXZTDtg"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "45cf9a2473676bb1a1355748d81b329d7aa005b16107c28abb77629aef7a6b16"
+hash = "0eac0013a35b2736e8286c1038f9cb39a074f527f8215dd771d3f3c7eca47f04"
 
 [versions]
 fabric = "0.18.4"

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "8b7e5b90cbe553d955ac35a1ef6db56be5e412d08ae59a994360163823731d6d"
+hash = "45cf9a2473676bb1a1355748d81b329d7aa005b16107c28abb77629aef7a6b16"
 
 [versions]
 fabric = "0.18.4"


### PR DESCRIPTION
- Add Necronomicon API mod
 Why this dev not listing the deps required for the mods.
- Update Skin Restorer mod to version 2.6.0